### PR TITLE
Feat/25 static block event filters

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -102,6 +104,24 @@ func setupIndex(cmd *cobra.Command, args []string) error {
 		endBlockEventFilterRegistry:   &filter.StaticBlockEventFilterRegistry{},
 	}
 
+	if indexer.cfg.Base.BlockEventFilterFile != "" {
+		f, err := os.Open(indexer.cfg.Base.BlockEventFilterFile)
+		if err != nil {
+			config.Log.Fatalf("Failed to open block event filter file %s: %s", indexer.cfg.Base.BlockEventFilterFile, err)
+		}
+
+		b, err := io.ReadAll(f)
+		if err != nil {
+			config.Log.Fatal("Failed to parse block event filter config", err)
+		}
+
+		indexer.blockEventFilterRegistries.beginBlockEventFilterRegistry.BlockEventFilters, indexer.blockEventFilterRegistries.beginBlockEventFilterRegistry.RollingWindowEventFilters, indexer.blockEventFilterRegistries.endBlockEventFilterRegistry.BlockEventFilters, indexer.blockEventFilterRegistries.endBlockEventFilterRegistry.RollingWindowEventFilters, err = config.ParseJsonFilterConfig(b)
+
+		if err != nil {
+			config.Log.Fatal("Failed to parse block event filter config", err)
+		}
+
+	}
 	return nil
 }
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -115,7 +115,7 @@ func setupIndex(cmd *cobra.Command, args []string) error {
 			config.Log.Fatal("Failed to parse block event filter config", err)
 		}
 
-		indexer.blockEventFilterRegistries.beginBlockEventFilterRegistry.BlockEventFilters, indexer.blockEventFilterRegistries.beginBlockEventFilterRegistry.RollingWindowEventFilters, indexer.blockEventFilterRegistries.endBlockEventFilterRegistry.BlockEventFilters, indexer.blockEventFilterRegistries.endBlockEventFilterRegistry.RollingWindowEventFilters, err = config.ParseJsonFilterConfig(b)
+		indexer.blockEventFilterRegistries.beginBlockEventFilterRegistry.BlockEventFilters, indexer.blockEventFilterRegistries.beginBlockEventFilterRegistry.RollingWindowEventFilters, indexer.blockEventFilterRegistries.endBlockEventFilterRegistry.BlockEventFilters, indexer.blockEventFilterRegistries.endBlockEventFilterRegistry.RollingWindowEventFilters, err = config.ParseJSONFilterConfig(b)
 
 		if err != nil {
 			config.Log.Fatal("Failed to parse block event filter config", err)

--- a/config.toml.example
+++ b/config.toml.example
@@ -25,6 +25,7 @@ api = "" # node api endpoint
 rpc-workers = 1
 rpc-retry-attempts=0 #RPC queries are configured to retry if failed. This value sets how many retries to do before giving up. (-1 for indefinite retries)
 rpc-retry-max-wait=30 #RPC query failure backoff max wait time in seconds
+block-event-filter-file = "filters.json"
 
 #Probe config options
 [probe]

--- a/config/filter_config.go
+++ b/config/filter_config.go
@@ -41,10 +41,9 @@ type BlockEventFilterConfig struct {
 	Inclusive  bool              `json:"inclusive"`
 }
 
-func ParseJsonFilterConfig(configJson []byte) ([]filter.BlockEventFilter, []filter.RollingWindowBlockEventFilter, []filter.BlockEventFilter, []filter.RollingWindowBlockEventFilter, error) {
+func ParseJSONFilterConfig(configJSON []byte) ([]filter.BlockEventFilter, []filter.RollingWindowBlockEventFilter, []filter.BlockEventFilter, []filter.RollingWindowBlockEventFilter, error) {
 	config := blockEventFilterConfigs{}
-	err := json.Unmarshal(configJson, &config)
-
+	err := json.Unmarshal(configJSON, &config)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -71,7 +70,6 @@ func ParseLifecycleConfig(lifecycleConfig []json.RawMessage) ([]filter.BlockEven
 		newFilter := BlockEventFilterConfig{}
 
 		err := json.Unmarshal(beginFilters, &newFilter)
-
 		if err != nil {
 			parserError := fmt.Errorf("error parsing filter at index %d: %s", index, err)
 			return nil, nil, parserError
@@ -93,7 +91,7 @@ func ParseLifecycleConfig(lifecycleConfig []json.RawMessage) ([]filter.BlockEven
 					parserError := fmt.Errorf("error parsing rolling window filter at index %d and subfilter index %d: %s", index, subfilterIndex, err)
 					return nil, nil, parserError
 				}
-				parsedFilter, err := ParseJsonFilterConfigFromType(newSubFilter.Type, subfilter)
+				parsedFilter, err := ParseJSONFilterConfigFromType(newSubFilter.Type, subfilter)
 				if err != nil {
 					parserError := fmt.Errorf("error parsing rolling window filter at index %d and subfilter index %d: %s", index, subfilterIndex, err)
 					return nil, nil, parserError
@@ -108,7 +106,7 @@ func ParseLifecycleConfig(lifecycleConfig []json.RawMessage) ([]filter.BlockEven
 			}
 			rollingWindowFilters = append(rollingWindowFilters, newRollingFilter)
 		case SingleBlockEventFilterIncludes(newFilter.Type):
-			parsedFilter, err := ParseJsonFilterConfigFromType(newFilter.Type, beginFilters)
+			parsedFilter, err := ParseJSONFilterConfigFromType(newFilter.Type, beginFilters)
 			if err != nil {
 				parserError := fmt.Errorf("error parsing filter at index %d: %s", index, err)
 				return nil, nil, parserError
@@ -133,13 +131,12 @@ func ParseLifecycleConfig(lifecycleConfig []json.RawMessage) ([]filter.BlockEven
 	return singleEventFilters, rollingWindowFilters, nil
 }
 
-func ParseJsonFilterConfigFromType(filterType string, configJson []byte) (filter.BlockEventFilter, error) {
+func ParseJSONFilterConfigFromType(filterType string, configJSON []byte) (filter.BlockEventFilter, error) {
 	switch filterType {
 	case EventTypeKey:
 		newFilter := filter.DefaultBlockEventTypeFilter{}
 
-		err := json.Unmarshal(configJson, &newFilter)
-
+		err := json.Unmarshal(configJSON, &newFilter)
 		if err != nil {
 			return nil, err
 		}
@@ -147,8 +144,7 @@ func ParseJsonFilterConfigFromType(filterType string, configJson []byte) (filter
 	case EventTypeAndAttributeValueKey:
 		newFilter := filter.DefaultBlockEventTypeAndAttributeValueFilter{}
 
-		err := json.Unmarshal(configJson, &newFilter)
-
+		err := json.Unmarshal(configJSON, &newFilter)
 		if err != nil {
 			return nil, err
 		}
@@ -156,8 +152,7 @@ func ParseJsonFilterConfigFromType(filterType string, configJson []byte) (filter
 	case RegexEventTypeKey:
 		newFilter := filter.RegexBlockEventTypeFilter{}
 
-		err := json.Unmarshal(configJson, &newFilter)
-
+		err := json.Unmarshal(configJSON, &newFilter)
 		if err != nil {
 			return nil, err
 		}

--- a/config/filter_config.go
+++ b/config/filter_config.go
@@ -158,7 +158,7 @@ func ParseJSONFilterConfigFromType(filterType string, configJSON []byte) (filter
 		}
 
 		// Reinit the filter so that regex compiles
-		regexFilter, err := filter.NewRegexBlockEventTypeAndAttributeValueFilter(newFilter.EventTypeRegexPattern, newFilter.Inclusive)
+		regexFilter, err := filter.NewRegexBlockEventFilter(newFilter.EventTypeRegexPattern, newFilter.Inclusive)
 		if err != nil {
 			return nil, err
 		}

--- a/config/filter_config.go
+++ b/config/filter_config.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/DefiantLabs/cosmos-indexer/filter"
+)
+
+type blockEventFilterConfigs struct {
+	BeginBlockFilters []json.RawMessage `json:"begin_block_filters"`
+	EndBlockFilters   []json.RawMessage `json:"end_block_filters"`
+}
+
+type BlockEventFilterConfig struct {
+	Type       string            `json:"type"`
+	Subfilters []json.RawMessage `json:"subfilters"`
+	Inclusive  bool              `json:"inclusive"`
+}
+
+func ParseJsonFilterConfig(configJson []byte) ([]filter.BlockEventFilter, []filter.RollingWindowBlockEventFilter, []filter.BlockEventFilter, []filter.RollingWindowBlockEventFilter, error) {
+	config := blockEventFilterConfigs{}
+	err := json.Unmarshal(configJson, &config)
+
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	beginBlockSingleEventFilters, beginBlockRollingWindowFilters, err := ParseLifecycleConfig(config.BeginBlockFilters)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	endBlockSingleEventFilters, endBlockRollingWindowFilters, err := ParseLifecycleConfig(config.EndBlockFilters)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	return beginBlockSingleEventFilters, beginBlockRollingWindowFilters, endBlockSingleEventFilters, endBlockRollingWindowFilters, nil
+}
+
+func ParseLifecycleConfig(lifecycleConfig []json.RawMessage) ([]filter.BlockEventFilter, []filter.RollingWindowBlockEventFilter, error) {
+	rollingWindowFilters := []filter.RollingWindowBlockEventFilter{}
+	singleEventFilters := []filter.BlockEventFilter{}
+	for index, beginFilters := range lifecycleConfig {
+
+		newFilter := BlockEventFilterConfig{}
+
+		err := json.Unmarshal(beginFilters, &newFilter)
+
+		if err != nil {
+			parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+			return nil, nil, parserError
+		}
+
+		err = validateBlockEventFilterConfig(newFilter)
+		if err != nil {
+			parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+			return nil, nil, parserError
+		}
+
+		switch newFilter.Type {
+		case "rolling_window":
+			eventPatterns := []filter.BlockEventFilter{}
+			for _, subfilter := range newFilter.Subfilters {
+				newSubFilter := BlockEventFilterConfig{}
+				err := json.Unmarshal(subfilter, &newSubFilter)
+				if err != nil {
+					parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+					return nil, nil, parserError
+				}
+				parsedFilter, err := ParseJsonFilterConfigFromType(newSubFilter.Type, subfilter, 0)
+				if err != nil {
+					parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+					return nil, nil, parserError
+				}
+				eventPatterns = append(eventPatterns, parsedFilter)
+			}
+			newRollingFilter := filter.NewDefaultRollingWindowBlockEventFilter(eventPatterns, newFilter.Inclusive)
+			valid, err := newRollingFilter.Valid()
+			if !valid || err != nil {
+				parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+				return nil, nil, parserError
+			}
+			rollingWindowFilters = append(rollingWindowFilters, newRollingFilter)
+		case "event_type":
+			parsedFilter, err := ParseJsonFilterConfigFromType(newFilter.Type, beginFilters, 0)
+			if err != nil {
+				parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+				return nil, nil, parserError
+			}
+			valid, err := parsedFilter.Valid()
+			if !valid || err != nil {
+				parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+				return nil, nil, parserError
+			}
+			singleEventFilters = append(singleEventFilters, parsedFilter)
+		case "event_type_and_attribute_value":
+			parsedFilter, err := ParseJsonFilterConfigFromType(newFilter.Type, beginFilters, 0)
+			if err != nil {
+				parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+				return nil, nil, parserError
+			}
+			valid, err := parsedFilter.Valid()
+			if !valid || err != nil {
+				parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+				return nil, nil, parserError
+			}
+			singleEventFilters = append(singleEventFilters, parsedFilter)
+		default:
+			parserError := fmt.Errorf("error parsing begin_block_filters at index %d: unknown filter type \"%s\"", index, newFilter.Type)
+			return nil, nil, parserError
+		}
+
+		if err != nil {
+			parserError := fmt.Errorf("error parsing begin_block_filters at index %d: %s", index, err)
+			return nil, nil, parserError
+		}
+	}
+
+	return singleEventFilters, rollingWindowFilters, nil
+}
+
+func ParseJsonFilterConfigFromType(filterType string, configJson []byte, level int) (filter.BlockEventFilter, error) {
+	switch filterType {
+	case "event_type":
+		newFilter := filter.DefaultBlockEventTypeFilter{}
+
+		err := json.Unmarshal(configJson, &newFilter)
+
+		if err != nil {
+			return nil, err
+		}
+		return newFilter, nil
+	case "event_type_and_attribute_value":
+		newFilter := filter.DefaultBlockEventTypeAndAttributeValueFilter{}
+
+		err := json.Unmarshal(configJson, &newFilter)
+
+		if err != nil {
+			return nil, err
+		}
+		return newFilter, nil
+	default:
+		return nil, fmt.Errorf("unknown filter type %s", filterType)
+	}
+}
+
+func validateBlockEventFilterConfig(config BlockEventFilterConfig) error {
+	if config.Type == "" {
+		return errors.New("filter config must have a type field")
+	}
+	return nil
+}

--- a/core/block_events.go
+++ b/core/block_events.go
@@ -102,7 +102,6 @@ func ProcessRPCBlockEvents(block *models.Block, blockEvents []abci.Event, blockL
 }
 
 func FilterRPCBlockEvents(blockEvents []db.BlockEventDBWrapper, filterRegistry filter.StaticBlockEventFilterRegistry) ([]db.BlockEventDBWrapper, error) {
-
 	// If there are no filters, just return the block events
 	if len(filterRegistry.BlockEventFilters) == 0 && len(filterRegistry.RollingWindowEventFilters) == 0 {
 		return blockEvents, nil
@@ -113,7 +112,7 @@ func FilterRPCBlockEvents(blockEvents []db.BlockEventDBWrapper, filterRegistry f
 	// If filters are defined, we treat filters as a whitelist, and only include block events that match the filters and are allowed
 	// Filters are evaluated in order, and the first filter that matches is the one that is used. Single block event filters are preferred in ordering.
 	for index, blockEvent := range blockEvents {
-		filterEvent := filter.FilterEventData{
+		filterEvent := filter.EventData{
 			Event:      blockEvent.BlockEvent,
 			Attributes: blockEvent.Attributes,
 		}
@@ -133,17 +132,16 @@ func FilterRPCBlockEvents(blockEvents []db.BlockEventDBWrapper, filterRegistry f
 				lastIndex := index + rollingWindowFilter.RollingWindowLength()
 				blockEventSlice := blockEvents[index:lastIndex]
 
-				filterEvents := make([]filter.FilterEventData, len(blockEventSlice))
+				filterEvents := make([]filter.EventData, len(blockEventSlice))
 
 				for index, blockEvent := range blockEventSlice {
-					filterEvents[index] = filter.FilterEventData{
+					filterEvents[index] = filter.EventData{
 						Event:      blockEvent.BlockEvent,
 						Attributes: blockEvent.Attributes,
 					}
 				}
 
 				patternMatches, err := rollingWindowFilter.EventsMatch(filterEvents)
-
 				if err != nil {
 					return nil, err
 				}
@@ -154,7 +152,6 @@ func FilterRPCBlockEvents(blockEvents []db.BlockEventDBWrapper, filterRegistry f
 					}
 				}
 			}
-
 		}
 	}
 

--- a/core/block_events.go
+++ b/core/block_events.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DefiantLabs/cosmos-indexer/db"
 	"github.com/DefiantLabs/cosmos-indexer/db/models"
+	"github.com/DefiantLabs/cosmos-indexer/filter"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 
@@ -98,4 +99,73 @@ func ProcessRPCBlockEvents(block *models.Block, blockEvents []abci.Event, blockL
 	}
 
 	return beginBlockEvents, nil
+}
+
+func FilterRPCBlockEvents(blockEvents []db.BlockEventDBWrapper, filterRegistry filter.StaticBlockEventFilterRegistry) ([]db.BlockEventDBWrapper, error) {
+
+	// If there are no filters, just return the block events
+	if len(filterRegistry.BlockEventFilters) == 0 && len(filterRegistry.RollingWindowEventFilters) == 0 {
+		return blockEvents, nil
+	}
+
+	filterIndexes := make(map[int]bool)
+
+	// If filters are defined, we treat filters as a whitelist, and only include block events that match the filters and are allowed
+	// Filters are evaluated in order, and the first filter that matches is the one that is used. Single block event filters are preferred in ordering.
+	for index, blockEvent := range blockEvents {
+		filterEvent := filter.FilterEventData{
+			Event:      blockEvent.BlockEvent,
+			Attributes: blockEvent.Attributes,
+		}
+
+		for _, filter := range filterRegistry.BlockEventFilters {
+			patternMatch, err := filter.EventMatches(filterEvent)
+			if err != nil {
+				return nil, err
+			}
+			if patternMatch {
+				filterIndexes[index] = filter.IncludeMatch()
+			}
+		}
+
+		if _, inMap := filterIndexes[index]; !inMap {
+			for _, rollingWindowFilter := range filterRegistry.RollingWindowEventFilters {
+				if index+rollingWindowFilter.RollingWindowLength() <= len(blockEvents) {
+					blockEventSlice := blockEvents[index : index+rollingWindowFilter.RollingWindowLength()]
+
+					filterEvents := make([]filter.FilterEventData, len(blockEventSlice))
+
+					for index, blockEvent := range blockEventSlice {
+						filterEvents[index] = filter.FilterEventData{
+							Event:      blockEvent.BlockEvent,
+							Attributes: blockEvent.Attributes,
+						}
+					}
+
+					patternMatches, err := rollingWindowFilter.EventsMatch(filterEvents)
+
+					if err != nil {
+						return nil, err
+					}
+
+					if patternMatches {
+						filterIndexes[index] = rollingWindowFilter.IncludeMatches()
+						break
+					}
+				}
+
+			}
+		}
+	}
+
+	// Filter the block events based on the indexes that matched the registered patterns
+	filteredBlockEvents := make([]db.BlockEventDBWrapper, 0)
+
+	for index, blockEvent := range blockEvents {
+		if filterIndexes[index] {
+			filteredBlockEvents = append(filteredBlockEvents, blockEvent)
+		}
+	}
+
+	return filteredBlockEvents, nil
 }

--- a/filter/block_event_filter_registry.go
+++ b/filter/block_event_filter_registry.go
@@ -1,0 +1,18 @@
+package filter
+
+type StaticBlockEventFilterRegistry struct {
+	BlockEventFilters         []BlockEventFilter
+	RollingWindowEventFilters []RollingWindowBlockEventFilter
+}
+
+func (r *StaticBlockEventFilterRegistry) RegisterBlockEventFilter(filter BlockEventFilter) {
+	r.BlockEventFilters = append(r.BlockEventFilters, filter)
+}
+
+func (r *StaticBlockEventFilterRegistry) RegisterRollingWindowBlockEventFilter(filter RollingWindowBlockEventFilter) {
+	r.RollingWindowEventFilters = append(r.RollingWindowEventFilters, filter)
+}
+
+func (r *StaticBlockEventFilterRegistry) NumFilters() int {
+	return len(r.BlockEventFilters) + len(r.RollingWindowEventFilters)
+}

--- a/filter/static_block_event_filters.go
+++ b/filter/static_block_event_filters.go
@@ -8,13 +8,13 @@ import (
 	"github.com/DefiantLabs/cosmos-indexer/db/models"
 )
 
-type FilterEventData struct {
+type EventData struct {
 	Event      models.BlockEvent
 	Attributes []models.BlockEventAttribute
 }
 
 type BlockEventFilter interface {
-	EventMatches(FilterEventData) (bool, error)
+	EventMatches(EventData) (bool, error)
 	IncludeMatch() bool
 	Valid() (bool, error)
 }
@@ -24,7 +24,7 @@ type DefaultBlockEventTypeFilter struct {
 	Inclusive bool   `json:"inclusive"`
 }
 
-func (f DefaultBlockEventTypeFilter) EventMatches(eventData FilterEventData) (bool, error) {
+func (f DefaultBlockEventTypeFilter) EventMatches(eventData EventData) (bool, error) {
 	return eventData.Event.BlockEventType.Type == f.EventType, nil
 }
 
@@ -33,7 +33,6 @@ func (f DefaultBlockEventTypeFilter) IncludeMatch() bool {
 }
 
 func (f DefaultBlockEventTypeFilter) Valid() (bool, error) {
-
 	if f.EventType != "" {
 		return true, nil
 	}
@@ -47,7 +46,7 @@ type RegexBlockEventTypeFilter struct {
 	Inclusive             bool `json:"inclusive"`
 }
 
-func (f RegexBlockEventTypeFilter) EventMatches(eventData FilterEventData) (bool, error) {
+func (f RegexBlockEventTypeFilter) EventMatches(eventData EventData) (bool, error) {
 	return f.eventTypeRegex.MatchString(eventData.Event.BlockEventType.Type), nil
 }
 
@@ -56,7 +55,6 @@ func (f RegexBlockEventTypeFilter) IncludeMatch() bool {
 }
 
 func (f RegexBlockEventTypeFilter) Valid() (bool, error) {
-
 	if f.eventTypeRegex != nil && f.EventTypeRegexPattern != "" {
 		return true, nil
 	}
@@ -71,7 +69,7 @@ type DefaultBlockEventTypeAndAttributeValueFilter struct {
 	Inclusive      bool   `json:"inclusive"`
 }
 
-func (f DefaultBlockEventTypeAndAttributeValueFilter) EventMatches(eventData FilterEventData) (bool, error) {
+func (f DefaultBlockEventTypeAndAttributeValueFilter) EventMatches(eventData EventData) (bool, error) {
 	if eventData.Event.BlockEventType.Type != f.EventType {
 		return false, nil
 	}
@@ -90,7 +88,6 @@ func (f DefaultBlockEventTypeAndAttributeValueFilter) IncludeMatch() bool {
 }
 
 func (f DefaultBlockEventTypeAndAttributeValueFilter) Valid() (bool, error) {
-
 	if f.EventType != "" && f.AttributeKey != "" && f.AttributeValue != "" {
 		return true, nil
 	}
@@ -99,7 +96,7 @@ func (f DefaultBlockEventTypeAndAttributeValueFilter) Valid() (bool, error) {
 }
 
 type RollingWindowBlockEventFilter interface {
-	EventsMatch([]FilterEventData) (bool, error)
+	EventsMatch([]EventData) (bool, error)
 	RollingWindowLength() int
 	IncludeMatches() bool
 	Valid() (bool, error)
@@ -110,7 +107,7 @@ type DefaultRollingWindowBlockEventFilter struct {
 	includeMatches bool
 }
 
-func (f DefaultRollingWindowBlockEventFilter) EventsMatch(eventData []FilterEventData) (bool, error) {
+func (f DefaultRollingWindowBlockEventFilter) EventsMatch(eventData []EventData) (bool, error) {
 	if len(eventData) < f.RollingWindowLength() {
 		return false, nil
 	}
@@ -146,7 +143,6 @@ func (f DefaultRollingWindowBlockEventFilter) Valid() (bool, error) {
 	}
 
 	return true, nil
-
 }
 
 func NewDefaultBlockEventTypeFilter(eventType string, inclusive bool) BlockEventFilter {

--- a/filter/static_block_event_filters.go
+++ b/filter/static_block_event_filters.go
@@ -1,0 +1,99 @@
+package filter
+
+import (
+	"github.com/DefiantLabs/cosmos-indexer/db/models"
+)
+
+type FilterEventData struct {
+	Event      models.BlockEvent
+	Attributes []models.BlockEventAttribute
+}
+
+type BlockEventFilter interface {
+	EventMatches(FilterEventData) (bool, error)
+	IncludeMatch() bool
+}
+
+type defaultBlockEventTypeFilter struct {
+	eventType string
+	inclusive bool
+}
+
+func (f *defaultBlockEventTypeFilter) EventMatches(eventData FilterEventData) (bool, error) {
+	return eventData.Event.BlockEventType.Type == f.eventType, nil
+}
+
+func (f *defaultBlockEventTypeFilter) IncludeMatch() bool {
+	return f.inclusive
+}
+
+type defaultBlockEventTypeAndAttributeValueFilter struct {
+	eventType      string
+	attributeKey   string
+	attributeValue string
+	inclusive      bool
+}
+
+func (f *defaultBlockEventTypeAndAttributeValueFilter) EventMatches(eventData FilterEventData) (bool, error) {
+	if eventData.Event.BlockEventType.Type != f.eventType {
+		return false, nil
+	}
+
+	for _, attr := range eventData.Attributes {
+		if attr.BlockEventAttributeKey.Key == f.attributeKey && attr.Value == f.attributeValue {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (f *defaultBlockEventTypeAndAttributeValueFilter) IncludeMatch() bool {
+	return f.inclusive
+}
+
+type RollingWindowBlockEventFilter interface {
+	EventsMatch([]FilterEventData) (bool, error)
+	RollingWindowLength() int
+	IncludeMatches() bool
+}
+
+type defaultRollingWindowBlockEventFilter struct {
+	eventPatterns  []BlockEventFilter
+	includeMatches bool
+}
+
+func (f *defaultRollingWindowBlockEventFilter) EventsMatch(eventData []FilterEventData) (bool, error) {
+	if len(eventData) < f.RollingWindowLength() {
+		return false, nil
+	}
+
+	for i, pattern := range f.eventPatterns {
+		patternMatches, err := pattern.EventMatches(eventData[i])
+		if !patternMatches || err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (f *defaultRollingWindowBlockEventFilter) RollingWindowLength() int {
+	return len(f.eventPatterns)
+}
+
+func (f *defaultRollingWindowBlockEventFilter) IncludeMatches() bool {
+	return f.includeMatches
+}
+
+func NewDefaultBlockEventTypeFilter(eventType string, inclusive bool) BlockEventFilter {
+	return &defaultBlockEventTypeFilter{eventType: eventType, inclusive: inclusive}
+}
+
+func NewDefaultBlockEventTypeAndAttributeValueFilter(eventType string, attributeKey string, attributeValue string, inclusive bool) BlockEventFilter {
+	return &defaultBlockEventTypeAndAttributeValueFilter{eventType: eventType, attributeKey: attributeKey, attributeValue: attributeValue, inclusive: inclusive}
+}
+
+func NewDefaultRollingWindowBlockEventFilter(eventPatterns []BlockEventFilter, includeMatches bool) RollingWindowBlockEventFilter {
+	return &defaultRollingWindowBlockEventFilter{eventPatterns: eventPatterns, includeMatches: includeMatches}
+}

--- a/filter/static_block_event_filters.go
+++ b/filter/static_block_event_filters.go
@@ -153,7 +153,7 @@ func NewDefaultBlockEventTypeAndAttributeValueFilter(eventType string, attribute
 	return &DefaultBlockEventTypeAndAttributeValueFilter{EventType: eventType, AttributeKey: attributeKey, AttributeValue: attributeValue, Inclusive: inclusive}
 }
 
-func NewRegexBlockEventTypeAndAttributeValueFilter(eventTypeRegex string, inclusive bool) (BlockEventFilter, error) {
+func NewRegexBlockEventFilter(eventTypeRegex string, inclusive bool) (BlockEventFilter, error) {
 	re, err := regexp.Compile(eventTypeRegex)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Implements a generalized block event filtering mechanism, which works like this:

1. Static block event filter types that are driven by pattern matching against events are provided in the filter/ package
    * The package provides generalized interfaces for single event and rolling window event filters
2. A config option is now provided to point to a JSON filter config file
3. The filter config file is parsed as a wrapper for setting up static filters according to config/ package requirements
4. Filter configs are pulled in during indexer setup if the file is provided
5. If any block event filters have been defined, they will be used to filter in and out events according to the filter setup

Closes #25 