### PR TITLE
feat/4 separate block processing and improvements

### DIFF
--- a/core/block_events.go
+++ b/core/block_events.go
@@ -25,12 +25,10 @@ func ChainSpecificBeginBlockerEventTypeHandlerBootstrap(chainID string) {
 	// Stub, for use when we have begin blocker events
 }
 
-func ProcessRPCBlockResults(blockResults *ctypes.ResultBlockResults) (*db.BlockDBWrapper, error) {
+func ProcessRPCBlockResults(block models.Block, blockResults *ctypes.ResultBlockResults) (*db.BlockDBWrapper, error) {
 	var blockDBWrapper db.BlockDBWrapper
 
-	blockDBWrapper.Block = &models.Block{
-		Height: blockResults.Height,
-	}
+	blockDBWrapper.Block = &block
 
 	blockDBWrapper.UniqueBlockEventAttributeKeys = make(map[string]models.BlockEventAttributeKey)
 	blockDBWrapper.UniqueBlockEventTypes = make(map[string]models.BlockEventType)

--- a/db/models/block.go
+++ b/db/models/block.go
@@ -5,12 +5,13 @@ import (
 )
 
 type Block struct {
-	ID        uint
-	TimeStamp time.Time
-	Height    int64 `gorm:"uniqueIndex:chainheight"`
-	ChainID   uint  `gorm:"uniqueIndex:chainheight"`
-	Chain     Chain
-	TxIndexed bool
+	ID                  uint
+	TimeStamp           time.Time
+	Height              int64 `gorm:"uniqueIndex:chainheight"`
+	ChainID             uint  `gorm:"uniqueIndex:chainheight"`
+	Chain               Chain
+	ProposerConsAddress string
+	TxIndexed           bool
 	// TODO: Should block event indexing be split out or rolled up?
 	BlockEventsIndexed bool
 }


### PR DESCRIPTION
Improve block processing by splitting it out into its own function that processes RPC data into app model. Use this data in both block event and tx database update methods.

Adds the Consensus Address of the proposer of the block to the database model.

Closes #4 
