### PR TITLE
Feat/message type filters and improving message parsing

### DIFF
--- a/config/filter_config.go
+++ b/config/filter_config.go
@@ -73,7 +73,6 @@ func ParseJSONFilterConfig(configJSON []byte) ([]filter.BlockEventFilter, []filt
 	}
 
 	messageTypeFilters, err := ParseTXMessageTypeConfig(config.MessageTypeFilters)
-
 	if err != nil {
 		newErr := fmt.Errorf("error parsing message_type_filters: %s", err)
 		return nil, nil, nil, nil, nil, newErr

--- a/config/index_config.go
+++ b/config/index_config.go
@@ -35,7 +35,7 @@ type indexBase struct {
 	TransactionIndexingEnabled bool   `mapstructure:"index-transactions"`
 	ExitWhenCaughtUp           bool   `mapstructure:"exit-when-caught-up"`
 	BlockEventIndexingEnabled  bool   `mapstructure:"index-block-events"`
-	BlockEventFilterFile       string `mapstructure:"block-event-filter-file"`
+	FilterFile                 string `mapstructure:"filter-file"`
 	Dry                        bool   `mapstructure:"dry"`
 }
 
@@ -56,7 +56,7 @@ func SetupIndexSpecificFlags(conf *IndexConfig, cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&conf.Base.TransactionIndexingEnabled, "base.index-transactions", false, "enable transaction indexing?")
 	cmd.PersistentFlags().BoolVar(&conf.Base.BlockEventIndexingEnabled, "base.index-block-events", false, "enable block beginblocker and endblocker event indexing?")
 	// filter configs
-	cmd.PersistentFlags().StringVar(&conf.Base.BlockEventFilterFile, "base.block-event-filter-file", "", "path to a file containing a JSON list of block event filters to apply to beginblocker and endblocker events")
+	cmd.PersistentFlags().StringVar(&conf.Base.FilterFile, "base.filter-file", "", "path to a file containing a JSON config of block event and message type filters to apply to beginblocker events, endblocker events and TX messages")
 	// other base setting
 	cmd.PersistentFlags().BoolVar(&conf.Base.Dry, "base.dry", false, "index the chain but don't insert data in the DB.")
 	cmd.PersistentFlags().StringVar(&conf.Base.API, "base.api", "", "node api endpoint")
@@ -108,10 +108,10 @@ func (conf *IndexConfig) Validate() error {
 		}
 	}
 
-	if conf.Base.BlockEventIndexingEnabled && conf.Base.BlockEventFilterFile != "" {
+	if conf.Base.BlockEventIndexingEnabled && conf.Base.FilterFile != "" {
 		// check if file exists
-		if _, err := os.Stat(conf.Base.BlockEventFilterFile); os.IsNotExist(err) {
-			return fmt.Errorf("base.block-event-filter-file %s does not exist", conf.Base.BlockEventFilterFile)
+		if _, err := os.Stat(conf.Base.FilterFile); os.IsNotExist(err) {
+			return fmt.Errorf("base.filter-file %s does not exist", conf.Base.FilterFile)
 		}
 	}
 
@@ -146,6 +146,10 @@ func CheckSuperfluousIndexKeys(keys []string) []string {
 	}
 
 	for _, key := range getValidConfigKeys(retryBase{}, "base") {
+		validKeys[key] = struct{}{}
+	}
+
+	for _, key := range getValidConfigKeys(flags{}, "flags") {
 		validKeys[key] = struct{}{}
 	}
 

--- a/config/index_config.go
+++ b/config/index_config.go
@@ -108,7 +108,7 @@ func (conf *IndexConfig) Validate() error {
 		}
 	}
 
-	if conf.Base.BlockEventIndexingEnabled && conf.Base.FilterFile != "" {
+	if conf.Base.FilterFile != "" {
 		// check if file exists
 		if _, err := os.Stat(conf.Base.FilterFile); os.IsNotExist(err) {
 			return fmt.Errorf("base.filter-file %s does not exist", conf.Base.FilterFile)

--- a/core/decoding.go
+++ b/core/decoding.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"errors"
+
+	probeClient "github.com/DefiantLabs/probe/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
+)
+
+// Provides an in-app tx decoder.
+// The primary use-case for this function is to allow fallback decoding if a TX fails to decode after RPC requests.
+// This can happen in a number of scenarios, but mainly due to missing proto definitions.
+// We can attempt a personal decode of the TX, and see if we can continue indexing based on in-app conditions (such as message type filters).
+// This function skips a large chunk of decoding validations, and is not recommended for general use. Its main point is to skip errors that in
+// default Cosmos TX decoders would cause the entire decode to fail.
+func InAppTxDecoder(cdc probeClient.Codec) sdk.TxDecoder {
+	return func(txBytes []byte) (sdk.Tx, error) {
+		var raw tx.TxRaw
+		var err error
+
+		err = cdc.Marshaler.Unmarshal(txBytes, &raw)
+		if err != nil {
+			return nil, err
+		}
+
+		var body tx.TxBody
+
+		err = body.Unmarshal(raw.BodyBytes)
+		if err != nil {
+			return nil, errors.New("failed to unmarshal tx body")
+		}
+
+		for _, any := range body.Messages {
+			var msg sdk.Msg
+			// We deliberately ignore errors here to build up a
+			// list of properly decoded messages for later analysis.
+			cdc.Marshaler.UnpackAny(any, &msg) //nolint:errcheck
+		}
+
+		var authInfo tx.AuthInfo
+
+		err = cdc.Marshaler.Unmarshal(raw.AuthInfoBytes, &authInfo)
+		if err != nil {
+			return nil, errors.New("failed to unmarshal auth info")
+		}
+
+		theTx := &tx.Tx{
+			Body:       &body,
+			AuthInfo:   &authInfo,
+			Signatures: raw.Signatures,
+		}
+
+		return theTx, nil
+	}
+}

--- a/filter/message_type_filters.go
+++ b/filter/message_type_filters.go
@@ -1,0 +1,62 @@
+package filter
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+type MessageTypeFilter interface {
+	MessageTypeMatches(MessageTypeData) (bool, error)
+	Valid() (bool, error)
+}
+
+type MessageTypeData struct {
+	MessageType string
+}
+
+type DefaultMessageTypeFilter struct {
+	MessageType string `json:"message_type"`
+}
+
+type MessageTypeRegexFilter struct {
+	MessageTypeRegexPattern string `json:"message_type_regex"`
+	messageTypeRegex        *regexp.Regexp
+}
+
+func (f DefaultMessageTypeFilter) MessageTypeMatches(messageTypeData MessageTypeData) (bool, error) {
+	return messageTypeData.MessageType == f.MessageType, nil
+}
+
+func (f MessageTypeRegexFilter) MessageTypeMatches(messageTypeData MessageTypeData) (bool, error) {
+	return f.messageTypeRegex.MatchString(messageTypeData.MessageType), nil
+}
+
+func (f DefaultMessageTypeFilter) Valid() (bool, error) {
+	if f.MessageType != "" {
+		return true, nil
+	}
+
+	return false, errors.New("MessageType must be set")
+}
+
+func (f MessageTypeRegexFilter) Valid() (bool, error) {
+	if f.messageTypeRegex != nil && f.MessageTypeRegexPattern != "" {
+		return true, nil
+	}
+
+	return false, errors.New("MessageTypeRegexPattern must be set")
+}
+
+func NewRegexMessageTypeFilter(messageTypeRegexPattern string) (MessageTypeRegexFilter, error) {
+	messageTypeRegex, err := regexp.Compile(messageTypeRegexPattern)
+
+	if err != nil {
+		return MessageTypeRegexFilter{}, fmt.Errorf("error compiling message type regex: %s", err)
+	}
+
+	return MessageTypeRegexFilter{
+		MessageTypeRegexPattern: messageTypeRegexPattern,
+		messageTypeRegex:        messageTypeRegex,
+	}, nil
+}

--- a/filter/message_type_filters.go
+++ b/filter/message_type_filters.go
@@ -50,7 +50,6 @@ func (f MessageTypeRegexFilter) Valid() (bool, error) {
 
 func NewRegexMessageTypeFilter(messageTypeRegexPattern string) (MessageTypeRegexFilter, error) {
 	messageTypeRegex, err := regexp.Compile(messageTypeRegexPattern)
-
 	if err != nil {
 		return MessageTypeRegexFilter{}, fmt.Errorf("error compiling message type regex: %s", err)
 	}

--- a/filter/static_block_event_filters.go
+++ b/filter/static_block_event_filters.go
@@ -37,7 +37,7 @@ func (f DefaultBlockEventTypeFilter) Valid() (bool, error) {
 		return true, nil
 	}
 
-	return true, errors.New("EventType must be set")
+	return false, errors.New("EventType must be set")
 }
 
 type RegexBlockEventTypeFilter struct {
@@ -59,7 +59,7 @@ func (f RegexBlockEventTypeFilter) Valid() (bool, error) {
 		return true, nil
 	}
 
-	return true, errors.New("EventTypeRegexPattern must be set")
+	return false, errors.New("EventTypeRegexPattern must be set")
 }
 
 type DefaultBlockEventTypeAndAttributeValueFilter struct {


### PR DESCRIPTION
Adds the following:

1. A way to filter TX message indexing by configuration files. Adds this into the workflow for TX parsing to skip indexing message types by type URL string or regex
2. Add better decoding handling of TXes in app to allow getting to the raw Type URL without error
3. If the message fails decoding but is filtered out, we skip message parsing and do not raise decoding errors