### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
     - |
       cosmos-indexer index \
       --log.pretty=${PRETTY_LOG} \
-      --log.level=${LOG_LEVEL \
+      --log.level=${LOG_LEVEL} \
       --base.index-transactions=${INDEX_TRANSACTIONS} \
       --base.index-block-events=${INDEX_BLOCK_EVENTS} \
       --base.start-block=${START_BLOCK} \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
       --base.index-transactions=${INDEX_TRANSACTIONS} \
       --base.index-block-events=${INDEX_BLOCK_EVENTS} \
       --base.start-block=${START_BLOCK} \
-      --base.end-block=-${END_BLOCK} \
+      --base.end-block=${END_BLOCK} \
       --base.throttling=${THROTTLING} \
       --base.rpc-workers=${RPC_WORKERS} \
       --base.reindex=${REINDEX} \


### PR DESCRIPTION
- Add missing "}" to fix docker-compose.yaml syntax.
- Remove negative sign from cosmos-indexer command END_BLOCK argument to allow setting an arbitrary end block and properly read both "-1" and other non-zero end blocks as shown in the .env.example.

Cheers!