### PR TITLE
feat/post indexer setup channel data passing

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -43,7 +43,6 @@ var indexCmd = &cobra.Command{
 
 // GetBuiltinIndexer returns the indexer instance for the index command. Usable for customizing pre-run setup.
 func GetBuiltinIndexer() *indexerPackage.Indexer {
-
 	if indexer.PostSetupDatasetChannel == nil {
 		indexer.PostSetupDatasetChannel = make(chan *indexerPackage.PostSetupDataset)
 	}

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -43,11 +43,20 @@ var indexCmd = &cobra.Command{
 
 // GetBuiltinIndexer returns the indexer instance for the index command. Usable for customizing pre-run setup.
 func GetBuiltinIndexer() *indexerPackage.Indexer {
+
+	if indexer.PostSetupDatasetChannel == nil {
+		indexer.PostSetupDatasetChannel = make(chan *indexerPackage.PostSetupDataset)
+	}
+
 	return &indexer
 }
 
 // setupIndex loads the configuration from file and command line flags, validates the configuration, and sets up the logger and database connection.
 func setupIndex(cmd *cobra.Command, args []string) error {
+	if indexer.PostSetupDatasetChannel == nil {
+		indexer.PostSetupDatasetChannel = make(chan *indexerPackage.PostSetupDataset)
+	}
+
 	BindFlags(cmd, viperConf)
 
 	err := indexer.Config.Validate()
@@ -176,6 +185,16 @@ func setupIndexer() *indexerPackage.Indexer {
 	if err != nil {
 		config.Log.Fatal("Error querying chain status.", err)
 	}
+
+	if indexer.PostSetupDatasetChannel != nil {
+		indexer.PostSetupDatasetChannel <- &indexerPackage.PostSetupDataset{
+			Config:      indexer.Config,
+			DryRun:      indexer.DryRun,
+			ChainClient: indexer.ChainClient,
+		}
+	}
+
+	close(indexer.PostSetupDatasetChannel)
 
 	return &indexer
 }

--- a/indexer/types.go
+++ b/indexer/types.go
@@ -12,6 +12,14 @@ import (
 	"gorm.io/gorm"
 )
 
+// DB is not safe to add here just yet, since the index command in cmd/ defers a close of the DB connection
+// Maybe the defer should be removed?
+type PostSetupDataset struct {
+	Config      *config.IndexConfig
+	DryRun      bool
+	ChainClient *client.ChainClient
+}
+
 type PostIndexCustomMessageDataset struct {
 	Config         config.IndexConfig
 	DB             *gorm.DB
@@ -37,6 +45,7 @@ type Indexer struct {
 	CustomMessageParserTrackers         map[string]models.MessageParser       // Used for tracking message parsers in the database
 	CustomModels                        []any
 	PostIndexCustomMessageFunction      func(*PostIndexCustomMessageDataset) error // Called post indexing of the custom messages with the indexed dataset, useful for custom indexing on the whole dataset or for additional processing
+	PostSetupDatasetChannel             chan *PostSetupDataset                     // passes configured indexer data to any reader
 }
 
 type BlockEventFilterRegistries struct {


### PR DESCRIPTION
Add an optional channel for passing post-setup configured indexer values along to callers