### PR TITLE
pharr117/block events sdk v0.4x and v0.5x normalization

### DIFF
--- a/core/block_events.go
+++ b/core/block_events.go
@@ -10,10 +10,10 @@ import (
 	"github.com/DefiantLabs/cosmos-indexer/db/models"
 	"github.com/DefiantLabs/cosmos-indexer/filter"
 	"github.com/DefiantLabs/cosmos-indexer/parsers"
-	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/DefiantLabs/cosmos-indexer/rpc"
 )
 
-func ProcessRPCBlockResults(conf config.IndexConfig, block models.Block, blockResults *ctypes.ResultBlockResults, customBeginBlockParsers map[string][]parsers.BlockEventParser, customEndBlockParsers map[string][]parsers.BlockEventParser) (*db.BlockDBWrapper, error) {
+func ProcessRPCBlockResults(conf config.IndexConfig, block models.Block, blockResults *rpc.CustomBlockResults, customBeginBlockParsers map[string][]parsers.BlockEventParser, customEndBlockParsers map[string][]parsers.BlockEventParser) (*db.BlockDBWrapper, error) {
 	var blockDBWrapper db.BlockDBWrapper
 
 	blockDBWrapper.Block = &block

--- a/core/processor.go
+++ b/core/processor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DefiantLabs/cosmos-indexer/config"
 	"github.com/DefiantLabs/cosmos-indexer/db/models"
+	"github.com/DefiantLabs/cosmos-indexer/rpc"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdkTypes "github.com/cosmos/cosmos-sdk/types"
 )
@@ -24,7 +25,7 @@ const (
 type FailedBlockHandler func(height int64, code BlockProcessingFailure, err error)
 
 // Process RPC Block data into the model object used by the application.
-func ProcessBlock(blockData *ctypes.ResultBlock, blockResultsData *ctypes.ResultBlockResults, chainID uint) (models.Block, error) {
+func ProcessBlock(blockData *ctypes.ResultBlock, blockResultsData *rpc.CustomBlockResults, chainID uint) (models.Block, error) {
 	block := models.Block{
 		Height:  blockData.Block.Height,
 		ChainID: chainID,

--- a/core/tx.go
+++ b/core/tx.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DefiantLabs/cosmos-indexer/db/models"
 	"github.com/DefiantLabs/cosmos-indexer/filter"
 	"github.com/DefiantLabs/cosmos-indexer/parsers"
+	"github.com/DefiantLabs/cosmos-indexer/rpc"
 	"github.com/DefiantLabs/cosmos-indexer/util"
 	"github.com/DefiantLabs/probe/client"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
@@ -31,7 +32,7 @@ func getUnexportedField(field reflect.Value) interface{} {
 	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface()
 }
 
-func ProcessRPCBlockByHeightTXs(cfg *config.IndexConfig, db *gorm.DB, cl *client.ChainClient, messageTypeFilters []filter.MessageTypeFilter, messageFilters []filter.MessageFilter, blockResults *coretypes.ResultBlock, resultBlockRes *coretypes.ResultBlockResults, customParsers map[string][]parsers.MessageParser) ([]dbTypes.TxDBWrapper, *time.Time, error) {
+func ProcessRPCBlockByHeightTXs(cfg *config.IndexConfig, db *gorm.DB, cl *client.ChainClient, messageTypeFilters []filter.MessageTypeFilter, messageFilters []filter.MessageFilter, blockResults *coretypes.ResultBlock, resultBlockRes *rpc.CustomBlockResults, customParsers map[string][]parsers.MessageParser) ([]dbTypes.TxDBWrapper, *time.Time, error) {
 	if len(blockResults.Block.Txs) != len(resultBlockRes.TxsResults) {
 		config.Log.Fatalf("blockResults & resultBlockRes: different length")
 	}

--- a/indexer/registration.go
+++ b/indexer/registration.go
@@ -16,7 +16,6 @@ func (indexer *Indexer) RegisterCustomModuleBasics(basics []module.AppModuleBasi
 }
 
 func (indexer *Indexer) RegisterCustomMsgTypesByTypeURLs(customMessageTypeURLSToTypes map[string]sdkTypes.Msg) error {
-
 	if indexer.CustomMsgTypeRegistry == nil {
 		indexer.CustomMsgTypeRegistry = make(map[string]sdkTypes.Msg)
 	}
@@ -24,9 +23,8 @@ func (indexer *Indexer) RegisterCustomMsgTypesByTypeURLs(customMessageTypeURLSTo
 	for url, msg := range customMessageTypeURLSToTypes {
 		if _, ok := indexer.CustomMsgTypeRegistry[url]; ok {
 			return fmt.Errorf("found duplicate message type with URL \"%s\", message types must be uniquely identified", url)
-		} else {
-			indexer.CustomMsgTypeRegistry[url] = msg
 		}
+		indexer.CustomMsgTypeRegistry[url] = msg
 	}
 
 	return nil


### PR DESCRIPTION
Normalize sdk v0.4x and v0.5x block events by unmerging sdk v0.5x FinalizeBlockEvents back into BeginBlock and EndBlock events

Closes #121 