### PR TITLE
Add /metrics endpoint exposing tax-indexer freshness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 .vscode/*
 log.txt
 .env
+bin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# cosmos-indexer-sdk — agent guide
+
+Fork of DefiantLabs `cosmos-indexer` (+ `probe`). The BryanLabs work lives on the
+**`tax-layer`** branch, which is what ships — `main` tracks upstream.
+
+## What this is
+A Go app that indexes any Cosmos SDK chain into a generalized Transaction/Event
+Postgres schema, plus a BryanLabs **tax layer** on top. It is the backend for the
+website's **/tax** section and replaced the retired `cosmos-tax-cli`.
+
+## What runs in production (built from this repo)
+Image `ghcr.io/bryanlabs/cosmos-tax-sdk` (built from `Dockerfile.tax`), deployed in
+k8s namespace `apps` as two trios (mainnet + a parallel `-testnet-*`):
+- `cosmos-tax-sdk-indexer` — writes txs/events into Postgres (`taxindexer`).
+- `cosmos-tax-sdk-api` — serves the tax HTTP API (Service `:8082`) (`taxapid`).
+- `cosmos-tax-sdk-postgres` — the database.
+
+## The BryanLabs tax layer (the part you'll usually touch)
+- `taxapi/` — the HTTP API: `server.go` (routes), `balances.go` (`/balance` = live
+  node read via `NODE_REST_API`, persisted to `balance_snapshots`), `form8949.go`,
+  `form990t.go` (reports/forms).
+- `taxapid/main.go` — the API daemon entrypoint.
+- `taxindexer/` — the indexing entrypoint; `tax/` — tax computation logic.
+- Upstream machinery (rarely touched): `cmd/`, `core/`, `cosmos/`, `db/`, `indexer/`,
+  `parsers/`, `probe/`, `rpc/`, `filter/`.
+
+## Who consumes it
+The platform mono-app `/tax` section. The web app calls this API via `TAX_SDK_API_URL`
+(mainnet events/forms, `cosmos-tax-sdk-api:8082`), `TAX_API_URL` (balances) and
+`TAX_API_URL_TESTNET` (`cosmos-tax-sdk-testnet-api:8082`), surfaced to the browser as
+`/api/tax/v1/{events,balances}` + `/api/tax/{report,forms,export}`. See
+`platform/apps/web/app/tax/AGENTS.md` and `platform/ARCHITECTURE.md` ("The Cosmos SDK
+indexer (tax)").
+
+## Gotchas
+- The top-level `README.md` is the **upstream** (generic) doc; the BryanLabs-specific
+  code is the `tax*` dirs + `Dockerfile.tax`, on the `tax-layer` branch.
+- Build the deployed image from `Dockerfile.tax`, not the plain `Dockerfile`.
+- Before trusting query results, confirm the indexer is caught up
+  (`cosmos-tax-sdk-indexer` logs).
+- Upstream docs: `docs/quickstart.md`, `docs/reference`, `docs/usage`.
+
+## Keep this current
+When you add/rename a tax API route or change how it's deployed, update this file and
+`platform/apps/web/app/tax/AGENTS.md` in the same change.

--- a/Dockerfile.tax
+++ b/Dockerfile.tax
@@ -1,0 +1,23 @@
+# Builds the tax stack on top of the cosmos-indexer SDK:
+#   taxindexer - generic indexer + tax classification layer (writes taxable_events)
+#   taxapid    - export API (Koinly/Summ/CoinLedger CSV + 8949) backed by the oracle
+#
+# Both are pure-Go static binaries (CGO off): wasmvm is only an indirect dep and is
+# never invoked, so no muslc/wasmvm static-lib dance is needed.
+FROM golang:1.22-alpine3.18 AS build
+WORKDIR /src
+RUN apk add --no-cache git
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETARCH=amd64
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/taxindexer ./taxindexer && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/taxapid ./taxapid
+
+FROM alpine:3.18
+RUN apk add --no-cache ca-certificates && adduser -D -u 1137 tax
+COPY --from=build /out/taxindexer /usr/local/bin/taxindexer
+COPY --from=build /out/taxapid /usr/local/bin/taxapid
+USER tax
+# Default entrypoint is the API; the indexer Deployment overrides command.
+ENTRYPOINT ["/usr/local/bin/taxapid"]

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 toolchain go1.22.1
 
 require (
+	github.com/CosmWasm/wasmd v0.40.0
 	github.com/DefiantLabs/probe v1.0.0
 	github.com/cometbft/cometbft v0.37.4
 	github.com/cosmos/cosmos-sdk v0.47.7
@@ -38,7 +39,6 @@ require (
 	github.com/99designs/keyring v1.2.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/ChainSafe/go-schnorrkel v1.0.0 // indirect
-	github.com/CosmWasm/wasmd v0.40.0 // indirect
 	github.com/CosmWasm/wasmvm v1.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect

--- a/tax/models.go
+++ b/tax/models.go
@@ -1,0 +1,48 @@
+// Package tax implements a taxable-event classification layer on top of the
+// cosmos-indexer SDK. It registers custom message parsers that turn raw Cosmos
+// messages/events into TaxableEvent rows, reaching parity with the legacy
+// cosmos-tax-cli for the events that matter on Cosmos Hub: bank transfers,
+// staking rewards, validator commission, and IBC in/out. Fees are already
+// captured generically by the SDK's Fee model, so they're read from there at
+// export time rather than duplicated here.
+package tax
+
+import (
+	"time"
+
+	"github.com/DefiantLabs/cosmos-indexer/db/models"
+)
+
+// Category is the taxable classification of an event.
+type Category string
+
+const (
+	CategoryTransfer   Category = "transfer"   // bank send/receive (direction derived per-address at export)
+	CategoryReward     Category = "reward"     // staking/distribution delegator reward (income)
+	CategoryCommission Category = "commission" // validator commission (income)
+	CategoryIBCOut     Category = "ibc_out"    // outbound IBC transfer
+	CategoryIBCIn      Category = "ibc_in"     // inbound IBC receive
+)
+
+// TaxableEvent is one classified coin movement, denormalized for fast
+// address+date-range export queries. A single message can produce several
+// (multi-send, multi-coin rewards), distinguished by SubIndex.
+type TaxableEvent struct {
+	ID        uint           `gorm:"primaryKey"`
+	MessageID uint           `gorm:"uniqueIndex:tax_msg_sub,priority:1"`
+	Message   models.Message `gorm:"foreignKey:MessageID"`
+	SubIndex  int            `gorm:"uniqueIndex:tax_msg_sub,priority:2"`
+
+	Category string `gorm:"index:idx_tax_category"`
+	// Base-denom integer amount as a string (e.g. "1234567" uatom).
+	Amount string
+	// On-chain base denom (e.g. "uatom", "ibc/<hash>"); resolved to a symbol at export.
+	Denom string
+
+	FromAddr string `gorm:"index:idx_tax_from"`
+	ToAddr   string `gorm:"index:idx_tax_to"`
+
+	BlockHeight int64     `gorm:"index:idx_tax_height"`
+	Timestamp   time.Time `gorm:"index:idx_tax_time"`
+	TxHash      string    `gorm:"index:idx_tax_txhash"`
+}

--- a/tax/models.go
+++ b/tax/models.go
@@ -23,6 +23,8 @@ const (
 	CategoryIBCOut     Category = "ibc_out"    // outbound IBC transfer
 	CategoryIBCIn      Category = "ibc_in"     // inbound IBC receive
 	CategoryNFTSale    Category = "nft_sale"   // CosmWasm NFT marketplace sale (disposal for seller, acquisition for buyer)
+	CategoryNFTMint    Category = "nft_mint"   // CosmWasm NFT mint (acquisition; basis = mint cost)
+	CategorySwap       Category = "swap"       // CosmWasm DEX swap leg (offer = disposal, return = acquisition)
 )
 
 // TaxableEvent is one classified coin movement, denormalized for fast

--- a/tax/models.go
+++ b/tax/models.go
@@ -22,6 +22,7 @@ const (
 	CategoryCommission Category = "commission" // validator commission (income)
 	CategoryIBCOut     Category = "ibc_out"    // outbound IBC transfer
 	CategoryIBCIn      Category = "ibc_in"     // inbound IBC receive
+	CategoryNFTSale    Category = "nft_sale"   // CosmWasm NFT marketplace sale (disposal for seller, acquisition for buyer)
 )
 
 // TaxableEvent is one classified coin movement, denormalized for fast
@@ -37,7 +38,12 @@ type TaxableEvent struct {
 	// Base-denom integer amount as a string (e.g. "1234567" uatom).
 	Amount string
 	// On-chain base denom (e.g. "uatom", "ibc/<hash>"); resolved to a symbol at export.
+	// For nft_sale, this is the denom the NFT was priced/paid in; Amount is the price.
 	Denom string
+
+	// Asset identifies a non-fungible asset for nft_sale events as
+	// "<collection>/<token_id>"; empty for fungible coin movements.
+	Asset string `gorm:"index:idx_tax_asset"`
 
 	FromAddr string `gorm:"index:idx_tax_from"`
 	ToAddr   string `gorm:"index:idx_tax_to"`

--- a/tax/parser.go
+++ b/tax/parser.go
@@ -127,6 +127,8 @@ func classify(cosmosMsg sdk.Msg, log *indexerTxTypes.LogMessage) []TaxableEvent 
 	// wasm-finalize-sale event carrying the asset, price, seller and buyer.
 	case *wasmtypes.MsgExecuteContract:
 		events = append(events, nftSaleEvents(log)...)
+		events = append(events, swapEvents(log)...)
+		events = append(events, nftMintEvents(log)...)
 
 	case *chantypes.MsgRecvPacket:
 		var data transfertypes.FungibleTokenPacketData
@@ -201,6 +203,106 @@ func nftSaleEvents(log *indexerTxTypes.LogMessage) []TaxableEvent {
 		})
 	}
 	return out
+}
+
+// swapEvents turns each CosmWasm DEX swap (wasm event, action=swap) into two
+// taxable legs for the receiver: a disposal of the offered asset and an
+// acquisition of the returned asset (a crypto-to-crypto trade).
+func swapEvents(log *indexerTxTypes.LogMessage) []TaxableEvent {
+	var out []TaxableEvent
+	for _, ev := range log.Events {
+		if ev.Type != "wasm" {
+			continue
+		}
+		a := attrMap(ev)
+		if a["action"] != "swap" {
+			continue
+		}
+		recv := a["receiver"]
+		if recv == "" || a["offer_asset"] == "" || a["ask_asset"] == "" {
+			continue
+		}
+		// Disposal: the offered asset leaves the receiver.
+		out = append(out, TaxableEvent{
+			Category: string(CategorySwap),
+			FromAddr: recv,
+			Amount:   a["offer_amount"], Denom: a["offer_asset"],
+		})
+		// Acquisition: the returned asset arrives.
+		out = append(out, TaxableEvent{
+			Category: string(CategorySwap),
+			ToAddr:   recv,
+			Amount:   a["return_amount"], Denom: a["ask_asset"],
+		})
+	}
+	return out
+}
+
+// nftMintEvents turns each CosmWasm NFT mint (wasm event, action=mint) into an
+// acquisition for the owner, with the mint cost (coins the owner spent in this
+// message) as the basis.
+func nftMintEvents(log *indexerTxTypes.LogMessage) []TaxableEvent {
+	var out []TaxableEvent
+	for _, ev := range log.Events {
+		if ev.Type != "wasm" {
+			continue
+		}
+		a := attrMap(ev)
+		if a["action"] != "mint" || a["token_id"] == "" {
+			continue
+		}
+		owner := a["owner"]
+		if owner == "" {
+			owner = a["minter"]
+		}
+		collection := a["_contract_address"]
+		// Mint cost = what the owner spent in this message (the mint price).
+		cost := coinsSpentBy(log, owner)
+		amount, denom := "", ""
+		if len(cost) > 0 {
+			amount, denom = cost[0].Amount.String(), cost[0].Denom
+		}
+		out = append(out, TaxableEvent{
+			Category: string(CategoryNFTMint),
+			ToAddr:   owner,
+			Amount:   amount, Denom: denom,
+			Asset: collection + "/" + a["token_id"],
+		})
+	}
+	return out
+}
+
+// attrMap flattens an event's attributes into a map.
+func attrMap(ev indexerTxTypes.LogMessageEvent) map[string]string {
+	m := make(map[string]string, len(ev.Attributes))
+	for _, a := range ev.Attributes {
+		m[a.Key] = a.Value
+	}
+	return m
+}
+
+// coinsSpentBy sums the coins debited from target via coin_spent events.
+func coinsSpentBy(log *indexerTxTypes.LogMessage, target string) sdk.Coins {
+	total := sdk.NewCoins()
+	for _, ev := range log.Events {
+		if ev.Type != "coin_spent" {
+			continue
+		}
+		cur := ""
+		for _, a := range ev.Attributes {
+			switch a.Key {
+			case "spender":
+				cur = a.Value
+			case "amount":
+				if cur == target {
+					if coins, err := sdk.ParseCoinsNormalized(a.Value); err == nil {
+						total = total.Add(coins...)
+					}
+				}
+			}
+		}
+	}
+	return total
 }
 
 // rewardEvents emits CategoryReward events for the coins credited to delegator

--- a/tax/parser.go
+++ b/tax/parser.go
@@ -1,0 +1,188 @@
+package tax
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/DefiantLabs/cosmos-indexer/config"
+	indexerTxTypes "github.com/DefiantLabs/cosmos-indexer/cosmos/modules/tx"
+	"github.com/DefiantLabs/cosmos-indexer/db/models"
+	"github.com/DefiantLabs/cosmos-indexer/parsers"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	chantypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// MessageTypeURLs is every message type this parser classifies. main() registers
+// the same parser instance under each.
+var MessageTypeURLs = []string{
+	"/cosmos.bank.v1beta1.MsgSend",
+	"/cosmos.bank.v1beta1.MsgMultiSend",
+	"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+	"/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission",
+	"/ibc.applications.transfer.v1.MsgTransfer",
+	"/ibc.core.channel.v1.MsgRecvPacket",
+}
+
+// Parser implements parsers.MessageParser. One instance handles all the message
+// types above; ParseMessage type-switches and returns the taxable events for
+// that message (height/time/hash are filled in IndexMessage where the Message
+// model is available).
+type Parser struct{ ID string }
+
+func (p *Parser) Identifier() string { return p.ID }
+
+func (p *Parser) ParseMessage(cosmosMsg sdk.Msg, log *indexerTxTypes.LogMessage, cfg config.IndexConfig) (*any, error) {
+	var events []TaxableEvent
+
+	switch m := cosmosMsg.(type) {
+	case *banktypes.MsgSend:
+		for _, c := range m.Amount {
+			events = append(events, TaxableEvent{
+				Category: string(CategoryTransfer),
+				FromAddr: m.FromAddress, ToAddr: m.ToAddress,
+				Amount: c.Amount.String(), Denom: c.Denom,
+			})
+		}
+
+	case *banktypes.MsgMultiSend:
+		// SDK 0.47 restricts MultiSend to a single input; fall back to "" if not.
+		from := ""
+		if len(m.Inputs) == 1 {
+			from = m.Inputs[0].Address
+		}
+		for _, out := range m.Outputs {
+			for _, c := range out.Coins {
+				events = append(events, TaxableEvent{
+					Category: string(CategoryTransfer),
+					FromAddr: from, ToAddr: out.Address,
+					Amount: c.Amount.String(), Denom: c.Denom,
+				})
+			}
+		}
+
+	case *disttypes.MsgWithdrawDelegatorReward:
+		// Reward amount lives in the transfer/coin_received events to the delegator.
+		for _, c := range coinsReceivedBy(log, m.DelegatorAddress) {
+			events = append(events, TaxableEvent{
+				Category: string(CategoryReward),
+				ToAddr:   m.DelegatorAddress,
+				Amount:   c.Amount.String(), Denom: c.Denom,
+			})
+		}
+
+	case *disttypes.MsgWithdrawValidatorCommission:
+		// The recipient (validator's withdraw addr) isn't in the msg; take it from
+		// the coin_received events.
+		for recv, coins := range receivedCoinsByReceiver(log) {
+			for _, c := range coins {
+				events = append(events, TaxableEvent{
+					Category: string(CategoryCommission),
+					ToAddr:   recv,
+					Amount:   c.Amount.String(), Denom: c.Denom,
+				})
+			}
+		}
+
+	case *transfertypes.MsgTransfer:
+		events = append(events, TaxableEvent{
+			Category: string(CategoryIBCOut),
+			FromAddr: m.Sender, ToAddr: m.Receiver,
+			Amount: m.Token.Amount.String(), Denom: m.Token.Denom,
+		})
+
+	case *chantypes.MsgRecvPacket:
+		var data transfertypes.FungibleTokenPacketData
+		if err := json.Unmarshal(m.Packet.GetData(), &data); err == nil && data.Amount != "" {
+			events = append(events, TaxableEvent{
+				Category: string(CategoryIBCIn),
+				FromAddr: data.Sender, ToAddr: data.Receiver,
+				Amount: data.Amount, Denom: data.Denom,
+			})
+		}
+
+	default:
+		return nil, nil
+	}
+
+	if len(events) == 0 {
+		return nil, nil
+	}
+	v := any(events)
+	return &v, nil
+}
+
+func (p *Parser) IndexMessage(dataset *any, db *gorm.DB, message models.Message, _ []parsers.MessageEventWithAttributes, cfg config.IndexConfig) error {
+	events, ok := (*dataset).([]TaxableEvent)
+	if !ok {
+		return errors.New("tax: unexpected dataset type")
+	}
+	for i := range events {
+		events[i].MessageID = message.ID
+		events[i].SubIndex = i
+		events[i].BlockHeight = message.Tx.Block.Height
+		events[i].Timestamp = message.Tx.Block.TimeStamp
+		events[i].TxHash = message.Tx.Hash
+		if err := db.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "message_id"}, {Name: "sub_index"}},
+			DoUpdates: clause.AssignmentColumns([]string{"category", "amount", "denom", "from_addr", "to_addr", "block_height", "timestamp", "tx_hash"}),
+		}).Create(&events[i]).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// coinsReceivedBy sums the coins credited to target across this message's
+// transfer (recipient/amount) and coin_received (receiver/amount) events.
+func coinsReceivedBy(log *indexerTxTypes.LogMessage, target string) sdk.Coins {
+	total := sdk.NewCoins()
+	for _, ev := range log.Events {
+		if ev.Type != "transfer" && ev.Type != "coin_received" {
+			continue
+		}
+		cur := ""
+		for _, a := range ev.Attributes {
+			switch a.Key {
+			case "recipient", "receiver":
+				cur = a.Value
+			case "amount":
+				if cur == target {
+					if coins, err := sdk.ParseCoinsNormalized(a.Value); err == nil {
+						total = total.Add(coins...)
+					}
+				}
+			}
+		}
+	}
+	return total
+}
+
+// receivedCoinsByReceiver groups coin_received amounts by receiver (used for
+// validator commission, where the recipient isn't on the message).
+func receivedCoinsByReceiver(log *indexerTxTypes.LogMessage) map[string]sdk.Coins {
+	out := map[string]sdk.Coins{}
+	for _, ev := range log.Events {
+		if ev.Type != "coin_received" {
+			continue
+		}
+		cur := ""
+		for _, a := range ev.Attributes {
+			switch a.Key {
+			case "receiver":
+				cur = a.Value
+			case "amount":
+				if cur != "" {
+					if coins, err := sdk.ParseCoinsNormalized(a.Value); err == nil {
+						out[cur] = out[cur].Add(coins...)
+					}
+				}
+			}
+		}
+	}
+	return out
+}

--- a/tax/parser.go
+++ b/tax/parser.go
@@ -169,12 +169,21 @@ func rewardEvents(log *indexerTxTypes.LogMessage, delegator string) []TaxableEve
 	return out
 }
 
-// coinsReceivedBy sums the coins credited to target across this message's
-// transfer (recipient/amount) and coin_received (receiver/amount) events.
+// coinsReceivedBy sums the coins credited to target. coin_received and transfer
+// describe the SAME movement (SDK emits both), so we count ONLY coin_received,
+// falling back to transfer only when no coin_received event is present — summing
+// both would double the amount.
 func coinsReceivedBy(log *indexerTxTypes.LogMessage, target string) sdk.Coins {
+	primary := "transfer"
+	for _, ev := range log.Events {
+		if ev.Type == "coin_received" {
+			primary = "coin_received"
+			break
+		}
+	}
 	total := sdk.NewCoins()
 	for _, ev := range log.Events {
-		if ev.Type != "transfer" && ev.Type != "coin_received" {
+		if ev.Type != primary {
 			continue
 		}
 		cur := ""

--- a/tax/parser.go
+++ b/tax/parser.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/DefiantLabs/cosmos-indexer/config"
 	indexerTxTypes "github.com/DefiantLabs/cosmos-indexer/cosmos/modules/tx"
 	"github.com/DefiantLabs/cosmos-indexer/db/models"
@@ -14,7 +15,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	chantypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	"gorm.io/gorm"
@@ -281,6 +281,12 @@ func attrMap(ev indexerTxTypes.LogMessageEvent) map[string]string {
 	return m
 }
 
+// SDK event/attribute names matched while summing coin movements.
+const (
+	evCoinReceived = "coin_received"
+	attrAmount     = "amount"
+)
+
 // coinsSpentBy sums the coins debited from target via coin_spent events.
 func coinsSpentBy(log *indexerTxTypes.LogMessage, target string) sdk.Coins {
 	total := sdk.NewCoins()
@@ -293,7 +299,7 @@ func coinsSpentBy(log *indexerTxTypes.LogMessage, target string) sdk.Coins {
 			switch a.Key {
 			case "spender":
 				cur = a.Value
-			case "amount":
+			case attrAmount:
 				if cur == target {
 					if coins, err := sdk.ParseCoinsNormalized(a.Value); err == nil {
 						total = total.Add(coins...)
@@ -326,8 +332,8 @@ func rewardEvents(log *indexerTxTypes.LogMessage, delegator string) []TaxableEve
 func coinsReceivedBy(log *indexerTxTypes.LogMessage, target string) sdk.Coins {
 	primary := "transfer"
 	for _, ev := range log.Events {
-		if ev.Type == "coin_received" {
-			primary = "coin_received"
+		if ev.Type == evCoinReceived {
+			primary = evCoinReceived
 			break
 		}
 	}
@@ -341,7 +347,7 @@ func coinsReceivedBy(log *indexerTxTypes.LogMessage, target string) sdk.Coins {
 			switch a.Key {
 			case "recipient", "receiver":
 				cur = a.Value
-			case "amount":
+			case attrAmount:
 				if cur == target {
 					if coins, err := sdk.ParseCoinsNormalized(a.Value); err == nil {
 						total = total.Add(coins...)
@@ -358,7 +364,7 @@ func coinsReceivedBy(log *indexerTxTypes.LogMessage, target string) sdk.Coins {
 func receivedCoinsByReceiver(log *indexerTxTypes.LogMessage) map[string]sdk.Coins {
 	out := map[string]sdk.Coins{}
 	for _, ev := range log.Events {
-		if ev.Type != "coin_received" {
+		if ev.Type != evCoinReceived {
 			continue
 		}
 		cur := ""
@@ -366,7 +372,7 @@ func receivedCoinsByReceiver(log *indexerTxTypes.LogMessage) map[string]sdk.Coin
 			switch a.Key {
 			case "receiver":
 				cur = a.Value
-			case "amount":
+			case attrAmount:
 				if cur != "" {
 					if coins, err := sdk.ParseCoinsNormalized(a.Value); err == nil {
 						out[cur] = out[cur].Add(coins...)

--- a/tax/parser.go
+++ b/tax/parser.go
@@ -14,6 +14,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	chantypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	"gorm.io/gorm"
@@ -33,6 +34,7 @@ var MessageTypeURLs = []string{
 	"/cosmos.authz.v1beta1.MsgExec",
 	"/ibc.applications.transfer.v1.MsgTransfer",
 	"/ibc.core.channel.v1.MsgRecvPacket",
+	"/cosmwasm.wasm.v1.MsgExecuteContract",
 }
 
 // Parser implements parsers.MessageParser. One instance handles all the message
@@ -120,6 +122,12 @@ func classify(cosmosMsg sdk.Msg, log *indexerTxTypes.LogMessage) []TaxableEvent 
 			Amount: m.Token.Amount.String(), Denom: m.Token.Denom,
 		})
 
+	// CosmWasm contract calls. The dominant taxable case on Cosmos Hub is NFT
+	// marketplace sales (Stargaze Marketplace v2), which emit an authoritative
+	// wasm-finalize-sale event carrying the asset, price, seller and buyer.
+	case *wasmtypes.MsgExecuteContract:
+		events = append(events, nftSaleEvents(log)...)
+
 	case *chantypes.MsgRecvPacket:
 		var data transfertypes.FungibleTokenPacketData
 		if err := json.Unmarshal(m.Packet.GetData(), &data); err == nil && data.Amount != "" {
@@ -147,12 +155,52 @@ func (p *Parser) IndexMessage(dataset *any, db *gorm.DB, message models.Message,
 		events[i].TxHash = message.Tx.Hash
 		if err := db.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "message_id"}, {Name: "sub_index"}},
-			DoUpdates: clause.AssignmentColumns([]string{"category", "amount", "denom", "from_addr", "to_addr", "block_height", "timestamp", "tx_hash"}),
+			DoUpdates: clause.AssignmentColumns([]string{"category", "amount", "denom", "asset", "from_addr", "to_addr", "block_height", "timestamp", "tx_hash"}),
 		}).Create(&events[i]).Error; err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// nftSaleEvents turns each wasm-finalize-sale event (CosmWasm NFT marketplace,
+// e.g. Stargaze Marketplace v2) into a taxable NFT sale: the seller disposes the
+// NFT for `price` of `denom`, the buyer (nft_recipient) acquires it. One event
+// holds both parties; direction is derived per-address at export time.
+func nftSaleEvents(log *indexerTxTypes.LogMessage) []TaxableEvent {
+	var out []TaxableEvent
+	for _, ev := range log.Events {
+		if ev.Type != "wasm-finalize-sale" {
+			continue
+		}
+		var collection, tokenID, denom, price, seller, buyer string
+		for _, a := range ev.Attributes {
+			switch a.Key {
+			case "collection":
+				collection = a.Value
+			case "token_id":
+				tokenID = a.Value
+			case "denom":
+				denom = a.Value
+			case "price":
+				price = a.Value
+			case "seller_recipient":
+				seller = a.Value
+			case "nft_recipient":
+				buyer = a.Value
+			}
+		}
+		if price == "" || collection == "" {
+			continue
+		}
+		out = append(out, TaxableEvent{
+			Category: string(CategoryNFTSale),
+			FromAddr: seller, ToAddr: buyer,
+			Amount: price, Denom: denom,
+			Asset: collection + "/" + tokenID,
+		})
+	}
+	return out
 }
 
 // rewardEvents emits CategoryReward events for the coins credited to delegator

--- a/tax/parser.go
+++ b/tax/parser.go
@@ -3,14 +3,17 @@ package tax
 import (
 	"encoding/json"
 	"errors"
+	"strconv"
 
 	"github.com/DefiantLabs/cosmos-indexer/config"
 	indexerTxTypes "github.com/DefiantLabs/cosmos-indexer/cosmos/modules/tx"
 	"github.com/DefiantLabs/cosmos-indexer/db/models"
 	"github.com/DefiantLabs/cosmos-indexer/parsers"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	chantypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	"gorm.io/gorm"
@@ -22,21 +25,34 @@ import (
 var MessageTypeURLs = []string{
 	"/cosmos.bank.v1beta1.MsgSend",
 	"/cosmos.bank.v1beta1.MsgMultiSend",
+	"/cosmos.staking.v1beta1.MsgDelegate",
+	"/cosmos.staking.v1beta1.MsgUndelegate",
+	"/cosmos.staking.v1beta1.MsgBeginRedelegate",
 	"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
 	"/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission",
+	"/cosmos.authz.v1beta1.MsgExec",
 	"/ibc.applications.transfer.v1.MsgTransfer",
 	"/ibc.core.channel.v1.MsgRecvPacket",
 }
 
 // Parser implements parsers.MessageParser. One instance handles all the message
-// types above; ParseMessage type-switches and returns the taxable events for
-// that message (height/time/hash are filled in IndexMessage where the Message
-// model is available).
+// types above.
 type Parser struct{ ID string }
 
 func (p *Parser) Identifier() string { return p.ID }
 
 func (p *Parser) ParseMessage(cosmosMsg sdk.Msg, log *indexerTxTypes.LogMessage, cfg config.IndexConfig) (*any, error) {
+	events := classify(cosmosMsg, log)
+	if len(events) == 0 {
+		return nil, nil
+	}
+	v := any(events)
+	return &v, nil
+}
+
+// classify turns a single message + its event log into taxable events. It's a
+// standalone function so MsgExec can recurse into its inner messages.
+func classify(cosmosMsg sdk.Msg, log *indexerTxTypes.LogMessage) []TaxableEvent {
 	var events []TaxableEvent
 
 	switch m := cosmosMsg.(type) {
@@ -50,7 +66,6 @@ func (p *Parser) ParseMessage(cosmosMsg sdk.Msg, log *indexerTxTypes.LogMessage,
 		}
 
 	case *banktypes.MsgMultiSend:
-		// SDK 0.47 restricts MultiSend to a single input; fall back to "" if not.
 		from := ""
 		if len(m.Inputs) == 1 {
 			from = m.Inputs[0].Address
@@ -65,19 +80,19 @@ func (p *Parser) ParseMessage(cosmosMsg sdk.Msg, log *indexerTxTypes.LogMessage,
 			}
 		}
 
+	// Staking delegate/undelegate/redelegate are NOT taxable themselves, but the
+	// SDK auto-withdraws pending rewards on each — that reward is income.
+	case *stakingtypes.MsgDelegate:
+		events = append(events, rewardEvents(log, m.DelegatorAddress)...)
+	case *stakingtypes.MsgUndelegate:
+		events = append(events, rewardEvents(log, m.DelegatorAddress)...)
+	case *stakingtypes.MsgBeginRedelegate:
+		events = append(events, rewardEvents(log, m.DelegatorAddress)...)
+
 	case *disttypes.MsgWithdrawDelegatorReward:
-		// Reward amount lives in the transfer/coin_received events to the delegator.
-		for _, c := range coinsReceivedBy(log, m.DelegatorAddress) {
-			events = append(events, TaxableEvent{
-				Category: string(CategoryReward),
-				ToAddr:   m.DelegatorAddress,
-				Amount:   c.Amount.String(), Denom: c.Denom,
-			})
-		}
+		events = append(events, rewardEvents(log, m.DelegatorAddress)...)
 
 	case *disttypes.MsgWithdrawValidatorCommission:
-		// The recipient (validator's withdraw addr) isn't in the msg; take it from
-		// the coin_received events.
 		for recv, coins := range receivedCoinsByReceiver(log) {
 			for _, c := range coins {
 				events = append(events, TaxableEvent{
@@ -86,6 +101,16 @@ func (p *Parser) ParseMessage(cosmosMsg sdk.Msg, log *indexerTxTypes.LogMessage,
 					Amount:   c.Amount.String(), Denom: c.Denom,
 				})
 			}
+		}
+
+	case *authz.MsgExec:
+		inners, err := m.GetMessages()
+		if err != nil {
+			return nil
+		}
+		for i, inner := range inners {
+			sub := eventsForAuthzIndex(log, i)
+			events = append(events, classify(inner, sub)...)
 		}
 
 	case *transfertypes.MsgTransfer:
@@ -104,16 +129,9 @@ func (p *Parser) ParseMessage(cosmosMsg sdk.Msg, log *indexerTxTypes.LogMessage,
 				Amount: data.Amount, Denom: data.Denom,
 			})
 		}
-
-	default:
-		return nil, nil
 	}
 
-	if len(events) == 0 {
-		return nil, nil
-	}
-	v := any(events)
-	return &v, nil
+	return events
 }
 
 func (p *Parser) IndexMessage(dataset *any, db *gorm.DB, message models.Message, _ []parsers.MessageEventWithAttributes, cfg config.IndexConfig) error {
@@ -135,6 +153,20 @@ func (p *Parser) IndexMessage(dataset *any, db *gorm.DB, message models.Message,
 		}
 	}
 	return nil
+}
+
+// rewardEvents emits CategoryReward events for the coins credited to delegator
+// in this message's transfer/coin_received events (the auto-withdrawn reward).
+func rewardEvents(log *indexerTxTypes.LogMessage, delegator string) []TaxableEvent {
+	var out []TaxableEvent
+	for _, c := range coinsReceivedBy(log, delegator) {
+		out = append(out, TaxableEvent{
+			Category: string(CategoryReward),
+			ToAddr:   delegator,
+			Amount:   c.Amount.String(), Denom: c.Denom,
+		})
+	}
+	return out
 }
 
 // coinsReceivedBy sums the coins credited to target across this message's
@@ -185,4 +217,21 @@ func receivedCoinsByReceiver(log *indexerTxTypes.LogMessage) map[string]sdk.Coin
 		}
 	}
 	return out
+}
+
+// eventsForAuthzIndex returns a sub-log containing only the events tagged with
+// the given authz_msg_index, so an inner MsgExec message classifies against its
+// own events.
+func eventsForAuthzIndex(log *indexerTxTypes.LogMessage, idx int) *indexerTxTypes.LogMessage {
+	target := strconv.Itoa(idx)
+	sub := &indexerTxTypes.LogMessage{}
+	for _, ev := range log.Events {
+		for _, a := range ev.Attributes {
+			if a.Key == "authz_msg_index" && a.Value == target {
+				sub.Events = append(sub.Events, ev)
+				break
+			}
+		}
+	}
+	return sub
 }

--- a/tax/parser_test.go
+++ b/tax/parser_test.go
@@ -14,6 +14,8 @@ const (
 	del   = "cosmos1delegatoraddrxxxxxxxxxxxxxxxxxxxxxx"
 	val   = "cosmosvaloper1validatorxxxxxxxxxxxxxxxxxxxx"
 	other = "cosmos1otheraddrxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+	uatomDenom = "uatom"
 )
 
 func ev(t string, attrs ...[2]string) indexerTxTypes.LogMessageEvent {
@@ -25,9 +27,9 @@ func ev(t string, attrs ...[2]string) indexerTxTypes.LogMessageEvent {
 }
 
 func TestClassifyBankSend(t *testing.T) {
-	msg := &banktypes.MsgSend{FromAddress: del, ToAddress: other, Amount: sdk.NewCoins(sdk.NewInt64Coin("uatom", 100))}
+	msg := &banktypes.MsgSend{FromAddress: del, ToAddress: other, Amount: sdk.NewCoins(sdk.NewInt64Coin(uatomDenom, 100))}
 	out := classify(msg, &indexerTxTypes.LogMessage{})
-	if len(out) != 1 || out[0].Category != string(CategoryTransfer) || out[0].Amount != "100" || out[0].Denom != "uatom" || out[0].FromAddr != del || out[0].ToAddr != other {
+	if len(out) != 1 || out[0].Category != string(CategoryTransfer) || out[0].Amount != "100" || out[0].Denom != uatomDenom || out[0].FromAddr != del || out[0].ToAddr != other {
 		t.Fatalf("bank send classification wrong: %+v", out)
 	}
 }
@@ -76,7 +78,7 @@ func TestClassifyNFTSale(t *testing.T) {
 		ev("wasm-finalize-sale",
 			[2]string{"collection", "cosmos1coll"},
 			[2]string{"token_id", "468"},
-			[2]string{"denom", "uatom"},
+			[2]string{"denom", uatomDenom},
 			[2]string{"price", "30000000"},
 			[2]string{"seller_recipient", del},
 			[2]string{"nft_recipient", other},
@@ -87,7 +89,7 @@ func TestClassifyNFTSale(t *testing.T) {
 		t.Fatalf("want 1 nft sale, got %d: %+v", len(out), out)
 	}
 	e := out[0]
-	if e.Category != string(CategoryNFTSale) || e.Amount != "30000000" || e.Denom != "uatom" ||
+	if e.Category != string(CategoryNFTSale) || e.Amount != "30000000" || e.Denom != uatomDenom ||
 		e.FromAddr != del || e.ToAddr != other || e.Asset != "cosmos1coll/468" {
 		t.Fatalf("nft sale classification wrong: %+v", e)
 	}
@@ -112,7 +114,7 @@ func TestClassifySwap(t *testing.T) {
 		ev("wasm",
 			[2]string{"action", "swap"},
 			[2]string{"receiver", del},
-			[2]string{"offer_asset", "uatom"}, [2]string{"offer_amount", "330000"},
+			[2]string{"offer_asset", uatomDenom}, [2]string{"offer_amount", "330000"},
 			[2]string{"ask_asset", "factory/x/art"}, [2]string{"return_amount", "15362"},
 		),
 	}}
@@ -120,7 +122,7 @@ func TestClassifySwap(t *testing.T) {
 	if len(out) != 2 {
 		t.Fatalf("want 2 swap legs, got %d: %+v", len(out), out)
 	}
-	if out[0].FromAddr != del || out[0].Denom != "uatom" || out[0].Amount != "330000" {
+	if out[0].FromAddr != del || out[0].Denom != uatomDenom || out[0].Amount != "330000" {
 		t.Fatalf("offer leg wrong: %+v", out[0])
 	}
 	if out[1].ToAddr != del || out[1].Denom != "factory/x/art" || out[1].Amount != "15362" {
@@ -141,7 +143,7 @@ func TestClassifyNFTMint(t *testing.T) {
 	}}
 	out := nftMintEvents(log)
 	if len(out) != 1 || out[0].Category != string(CategoryNFTMint) || out[0].ToAddr != del ||
-		out[0].Asset != "coll1/1047" || out[0].Amount != "5000000" || out[0].Denom != "uatom" {
+		out[0].Asset != "coll1/1047" || out[0].Amount != "5000000" || out[0].Denom != uatomDenom {
 		t.Fatalf("nft mint classification wrong: %+v", out)
 	}
 }

--- a/tax/parser_test.go
+++ b/tax/parser_test.go
@@ -67,3 +67,16 @@ func TestClassifyAuthzExecRestake(t *testing.T) {
 		t.Fatalf("authz exec restake classification wrong: %+v", out)
 	}
 }
+
+// Both coin_received and transfer to the delegator (same movement) must count once.
+func TestClassifyRewardNoDoubleCount(t *testing.T) {
+	msg := &disttypes.MsgWithdrawDelegatorReward{DelegatorAddress: del, ValidatorAddress: val}
+	log := &indexerTxTypes.LogMessage{Events: []indexerTxTypes.LogMessageEvent{
+		ev("coin_received", [2]string{"receiver", del}, [2]string{"amount", "7240259uatom"}),
+		ev("transfer", [2]string{"recipient", del}, [2]string{"sender", val}, [2]string{"amount", "7240259uatom"}),
+	}}
+	out := classify(msg, log)
+	if len(out) != 1 || out[0].Amount != "7240259" {
+		t.Fatalf("double-count not prevented: %+v", out)
+	}
+}

--- a/tax/parser_test.go
+++ b/tax/parser_test.go
@@ -105,3 +105,43 @@ func TestClassifyRewardNoDoubleCount(t *testing.T) {
 		t.Fatalf("double-count not prevented: %+v", out)
 	}
 }
+
+// DEX swap (wasm action=swap) → two legs: dispose offer, acquire return.
+func TestClassifySwap(t *testing.T) {
+	log := &indexerTxTypes.LogMessage{Events: []indexerTxTypes.LogMessageEvent{
+		ev("wasm",
+			[2]string{"action", "swap"},
+			[2]string{"receiver", del},
+			[2]string{"offer_asset", "uatom"}, [2]string{"offer_amount", "330000"},
+			[2]string{"ask_asset", "factory/x/art"}, [2]string{"return_amount", "15362"},
+		),
+	}}
+	out := swapEvents(log)
+	if len(out) != 2 {
+		t.Fatalf("want 2 swap legs, got %d: %+v", len(out), out)
+	}
+	if out[0].FromAddr != del || out[0].Denom != "uatom" || out[0].Amount != "330000" {
+		t.Fatalf("offer leg wrong: %+v", out[0])
+	}
+	if out[1].ToAddr != del || out[1].Denom != "factory/x/art" || out[1].Amount != "15362" {
+		t.Fatalf("return leg wrong: %+v", out[1])
+	}
+}
+
+// NFT mint (wasm action=mint) → acquisition for owner with the spent cost.
+func TestClassifyNFTMint(t *testing.T) {
+	log := &indexerTxTypes.LogMessage{Events: []indexerTxTypes.LogMessageEvent{
+		ev("coin_spent", [2]string{"spender", del}, [2]string{"amount", "5000000uatom"}),
+		ev("wasm",
+			[2]string{"_contract_address", "coll1"},
+			[2]string{"action", "mint"},
+			[2]string{"owner", del},
+			[2]string{"token_id", "1047"},
+		),
+	}}
+	out := nftMintEvents(log)
+	if len(out) != 1 || out[0].Category != string(CategoryNFTMint) || out[0].ToAddr != del ||
+		out[0].Asset != "coll1/1047" || out[0].Amount != "5000000" || out[0].Denom != "uatom" {
+		t.Fatalf("nft mint classification wrong: %+v", out)
+	}
+}

--- a/tax/parser_test.go
+++ b/tax/parser_test.go
@@ -1,0 +1,69 @@
+package tax
+
+import (
+	"testing"
+
+	indexerTxTypes "github.com/DefiantLabs/cosmos-indexer/cosmos/modules/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+)
+
+const (
+	del   = "cosmos1delegatoraddrxxxxxxxxxxxxxxxxxxxxxx"
+	val   = "cosmosvaloper1validatorxxxxxxxxxxxxxxxxxxxx"
+	other = "cosmos1otheraddrxxxxxxxxxxxxxxxxxxxxxxxxxx"
+)
+
+func ev(t string, attrs ...[2]string) indexerTxTypes.LogMessageEvent {
+	e := indexerTxTypes.LogMessageEvent{Type: t}
+	for _, a := range attrs {
+		e.Attributes = append(e.Attributes, indexerTxTypes.Attribute{Key: a[0], Value: a[1]})
+	}
+	return e
+}
+
+func TestClassifyBankSend(t *testing.T) {
+	msg := &banktypes.MsgSend{FromAddress: del, ToAddress: other, Amount: sdk.NewCoins(sdk.NewInt64Coin("uatom", 100))}
+	out := classify(msg, &indexerTxTypes.LogMessage{})
+	if len(out) != 1 || out[0].Category != string(CategoryTransfer) || out[0].Amount != "100" || out[0].Denom != "uatom" || out[0].FromAddr != del || out[0].ToAddr != other {
+		t.Fatalf("bank send classification wrong: %+v", out)
+	}
+}
+
+func TestClassifyDelegatorRewardFromEvents(t *testing.T) {
+	msg := &disttypes.MsgWithdrawDelegatorReward{DelegatorAddress: del, ValidatorAddress: val}
+	log := &indexerTxTypes.LogMessage{Events: []indexerTxTypes.LogMessageEvent{
+		ev("coin_received", [2]string{"receiver", del}, [2]string{"amount", "500uatom"}),
+	}}
+	out := classify(msg, log)
+	if len(out) != 1 || out[0].Category != string(CategoryReward) || out[0].Amount != "500" || out[0].ToAddr != del {
+		t.Fatalf("reward classification wrong: %+v", out)
+	}
+}
+
+// A reward to a different address in the same log must NOT be attributed to del.
+func TestClassifyRewardIgnoresOtherReceiver(t *testing.T) {
+	msg := &disttypes.MsgWithdrawDelegatorReward{DelegatorAddress: del, ValidatorAddress: val}
+	log := &indexerTxTypes.LogMessage{Events: []indexerTxTypes.LogMessageEvent{
+		ev("coin_received", [2]string{"receiver", other}, [2]string{"amount", "500uatom"}),
+	}}
+	if out := classify(msg, log); len(out) != 0 {
+		t.Fatalf("expected no events for non-matching receiver, got %+v", out)
+	}
+}
+
+// REStake: MsgExec wrapping a delegator-reward withdraw, events tagged with
+// authz_msg_index, must unwrap to one reward event.
+func TestClassifyAuthzExecRestake(t *testing.T) {
+	inner := &disttypes.MsgWithdrawDelegatorReward{DelegatorAddress: del, ValidatorAddress: val}
+	exec := authz.NewMsgExec(sdk.AccAddress("grantee-bot-addr"), []sdk.Msg{inner})
+	log := &indexerTxTypes.LogMessage{Events: []indexerTxTypes.LogMessageEvent{
+		ev("coin_received", [2]string{"receiver", del}, [2]string{"amount", "750uatom"}, [2]string{"authz_msg_index", "0"}),
+	}}
+	out := classify(&exec, log)
+	if len(out) != 1 || out[0].Category != string(CategoryReward) || out[0].Amount != "750" || out[0].ToAddr != del {
+		t.Fatalf("authz exec restake classification wrong: %+v", out)
+	}
+}

--- a/tax/parser_test.go
+++ b/tax/parser_test.go
@@ -68,6 +68,31 @@ func TestClassifyAuthzExecRestake(t *testing.T) {
 	}
 }
 
+// A Stargaze-style NFT marketplace sale emits wasm-finalize-sale; classify it as
+// one nft_sale with the asset, price, seller and buyer. (Real event shape from
+// cosmoshub-4 height 31761365.)
+func TestClassifyNFTSale(t *testing.T) {
+	log := &indexerTxTypes.LogMessage{Events: []indexerTxTypes.LogMessageEvent{
+		ev("wasm-finalize-sale",
+			[2]string{"collection", "cosmos1coll"},
+			[2]string{"token_id", "468"},
+			[2]string{"denom", "uatom"},
+			[2]string{"price", "30000000"},
+			[2]string{"seller_recipient", del},
+			[2]string{"nft_recipient", other},
+		),
+	}}
+	out := nftSaleEvents(log)
+	if len(out) != 1 {
+		t.Fatalf("want 1 nft sale, got %d: %+v", len(out), out)
+	}
+	e := out[0]
+	if e.Category != string(CategoryNFTSale) || e.Amount != "30000000" || e.Denom != "uatom" ||
+		e.FromAddr != del || e.ToAddr != other || e.Asset != "cosmos1coll/468" {
+		t.Fatalf("nft sale classification wrong: %+v", e)
+	}
+}
+
 // Both coin_received and transfer to the delegator (same movement) must count once.
 func TestClassifyRewardNoDoubleCount(t *testing.T) {
 	msg := &disttypes.MsgWithdrawDelegatorReward{DelegatorAddress: del, ValidatorAddress: val}

--- a/taxapi/balances.go
+++ b/taxapi/balances.go
@@ -57,7 +57,10 @@ func GetBalanceSnapshotHistory(db *gorm.DB, address string) []BalanceSnapshot {
 
 // --- live node read (ported from cosmos-tax-cli/rest/balances.go) ---
 
-const uatomToAtom = 1_000_000.0
+const (
+	uatomToAtom = 1_000_000.0
+	denomUatom  = "uatom"
+)
 
 type atomHoldings struct{ Liquid, Staked, Reward float64 }
 
@@ -66,8 +69,12 @@ type balCoin struct {
 	Amount string `json:"amount"`
 }
 
+// balHTTP bounds live node reads; the default client has no timeout and would
+// hang a request indefinitely on a stuck node.
+var balHTTP = &http.Client{Timeout: 15 * time.Second}
+
 func balGetJSON(url string, out interface{}) error {
-	resp, err := http.Get(url)
+	resp, err := balHTTP.Get(url)
 	if err != nil {
 		return err
 	}
@@ -94,7 +101,7 @@ func getAtomHoldings(host, address string) (atomHoldings, error) {
 		return h, err
 	}
 	for _, c := range bal.Balances {
-		if c.Denom == "uatom" {
+		if c.Denom == denomUatom {
 			if v, err := strconv.ParseFloat(c.Amount, 64); err == nil {
 				h.Liquid = v / uatomToAtom
 			}
@@ -111,7 +118,7 @@ func getAtomHoldings(host, address string) (atomHoldings, error) {
 	}
 	var staked float64
 	for _, d := range del.DelegationResponses {
-		if d.Balance.Denom == "uatom" {
+		if d.Balance.Denom == denomUatom {
 			if v, err := strconv.ParseFloat(d.Balance.Amount, 64); err == nil {
 				staked += v
 			}
@@ -126,7 +133,7 @@ func getAtomHoldings(host, address string) (atomHoldings, error) {
 		return h, err
 	}
 	for _, c := range rew.Total {
-		if c.Denom == "uatom" {
+		if c.Denom == denomUatom {
 			if v, err := strconv.ParseFloat(c.Amount, 64); err == nil {
 				h.Reward = v / uatomToAtom
 			}

--- a/taxapi/balances.go
+++ b/taxapi/balances.go
@@ -1,0 +1,214 @@
+package taxapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// BalanceSnapshot is a point-in-time (daily) record of an address's ATOM
+// holdings, captured live from the node so historical lookups don't need a node.
+// Amounts are in ATOM (already divided by 1e6). One row per (address, date).
+// (Ported from the legacy cosmos-tax-cli so the SDK can fully replace it.)
+type BalanceSnapshot struct {
+	ID      uint
+	Address string    `gorm:"index:idx_bal_addr_date,priority:1,unique"`
+	Date    time.Time `gorm:"index:idx_bal_addr_date,priority:2,unique"`
+	Liquid  float64   // spendable bank balance
+	Staked  float64   // bonded delegations
+	Reward  float64   // unclaimed staking rewards
+	Height  int64
+}
+
+// UpsertBalanceSnapshot writes (or replaces) the snapshot for an address+date.
+func UpsertBalanceSnapshot(db *gorm.DB, s *BalanceSnapshot) error {
+	return db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "address"}, {Name: "date"}},
+		DoUpdates: clause.AssignmentColumns([]string{"liquid", "staked", "reward", "height"}),
+	}).Create(s).Error
+}
+
+// GetBalanceSnapshotAsOf returns the most recent snapshot at or before asOf (the
+// holdings "as of" that date), or the latest if asOf is zero. False if none.
+func GetBalanceSnapshotAsOf(db *gorm.DB, address string, asOf time.Time) (BalanceSnapshot, bool) {
+	var s BalanceSnapshot
+	q := db.Where("address = ?", address)
+	if !asOf.IsZero() {
+		q = q.Where("date <= ?", asOf)
+	}
+	res := q.Order("date desc").Limit(1).Find(&s)
+	return s, res.RowsAffected > 0
+}
+
+// GetBalanceSnapshotHistory returns all snapshots for an address ordered by date.
+func GetBalanceSnapshotHistory(db *gorm.DB, address string) []BalanceSnapshot {
+	var rows []BalanceSnapshot
+	db.Where("address = ?", address).Order("date asc").Find(&rows)
+	return rows
+}
+
+// --- live node read (ported from cosmos-tax-cli/rest/balances.go) ---
+
+const uatomToAtom = 1_000_000.0
+
+type atomHoldings struct{ Liquid, Staked, Reward float64 }
+
+type balCoin struct {
+	Denom  string `json:"denom"`
+	Amount string `json:"amount"`
+}
+
+func balGetJSON(url string, out interface{}) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d for %s", resp.StatusCode, url)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, out)
+}
+
+// getAtomHoldings reads liquid bank balance, bonded delegations, and unclaimed
+// rewards for an address from a node REST endpoint (host).
+func getAtomHoldings(host, address string) (atomHoldings, error) {
+	var h atomHoldings
+
+	var bal struct {
+		Balances []balCoin `json:"balances"`
+	}
+	if err := balGetJSON(fmt.Sprintf("%s/cosmos/bank/v1beta1/balances/%s?pagination.limit=1000", host, address), &bal); err != nil {
+		return h, err
+	}
+	for _, c := range bal.Balances {
+		if c.Denom == "uatom" {
+			if v, err := strconv.ParseFloat(c.Amount, 64); err == nil {
+				h.Liquid = v / uatomToAtom
+			}
+		}
+	}
+
+	var del struct {
+		DelegationResponses []struct {
+			Balance balCoin `json:"balance"`
+		} `json:"delegation_responses"`
+	}
+	if err := balGetJSON(fmt.Sprintf("%s/cosmos/staking/v1beta1/delegations/%s?pagination.limit=1000", host, address), &del); err != nil {
+		return h, err
+	}
+	var staked float64
+	for _, d := range del.DelegationResponses {
+		if d.Balance.Denom == "uatom" {
+			if v, err := strconv.ParseFloat(d.Balance.Amount, 64); err == nil {
+				staked += v
+			}
+		}
+	}
+	h.Staked = staked / uatomToAtom
+
+	var rew struct {
+		Total []balCoin `json:"total"`
+	}
+	if err := balGetJSON(fmt.Sprintf("%s/cosmos/distribution/v1beta1/delegators/%s/rewards", host, address), &rew); err != nil {
+		return h, err
+	}
+	for _, c := range rew.Total {
+		if c.Denom == "uatom" {
+			if v, err := strconv.ParseFloat(c.Amount, 64); err == nil {
+				h.Reward = v / uatomToAtom
+			}
+		}
+	}
+	return h, nil
+}
+
+// handleBalance serves pre-indexed (and live-fetched) ATOM holdings for an
+// address. Matches the legacy cosmos-tax-cli /balance contract so the mono-app's
+// TAX_API_URL can point here instead of the cli.
+//
+//	GET /balance?address=cosmos1...            -> latest (live from node, persisted)
+//	GET /balance?address=...&date=YYYY-MM-DD   -> holdings as of a date (from snapshots)
+//	GET /balance?address=...&history=true      -> full daily series
+//
+// Node REST endpoint for live reads comes from NODE_REST_API.
+func (s *Server) handleBalance(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	address := strings.TrimSpace(q.Get("address"))
+	if address == "" {
+		http.Error(w, "address is required", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+
+	if q.Get("history") == "true" {
+		rows := GetBalanceSnapshotHistory(s.db, address)
+		series := make([]map[string]any, 0, len(rows))
+		for _, b := range rows {
+			series = append(series, map[string]any{
+				"date": b.Date.UTC().Format("2006-01-02"), "liquid": b.Liquid,
+				"staked": b.Staked, "reward": b.Reward, "total": b.Liquid + b.Staked + b.Reward,
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"address": address, "symbol": "ATOM", "history": series})
+		return
+	}
+
+	// "As of" a past date: serve from snapshots only (can't historically re-fetch).
+	var asOf time.Time
+	if d := q.Get("date"); d != "" {
+		if t, err := time.Parse("2006-01-02", d); err == nil {
+			asOf = t
+		}
+	}
+	if !asOf.IsZero() {
+		if b, ok := GetBalanceSnapshotAsOf(s.db, address, asOf); ok {
+			writeBalance(w, address, b, false)
+			return
+		}
+		http.Error(w, "no balance snapshot for this address on or before that date", http.StatusNotFound)
+		return
+	}
+
+	// Latest: always read live from the node (current), persisting today's row so
+	// the history series accrues. Fall back to the newest cached snapshot if the
+	// node is unreachable.
+	if node := os.Getenv("NODE_REST_API"); node != "" {
+		if h, err := getAtomHoldings(node, address); err == nil {
+			today := nowUTC().Truncate(24 * time.Hour)
+			b := BalanceSnapshot{Address: address, Date: today, Liquid: h.Liquid, Staked: h.Staked, Reward: h.Reward}
+			_ = UpsertBalanceSnapshot(s.db, &b)
+			writeBalance(w, address, b, true)
+			return
+		}
+	}
+	if b, ok := GetBalanceSnapshotAsOf(s.db, address, time.Time{}); ok {
+		writeBalance(w, address, b, false)
+		return
+	}
+	http.Error(w, "no balance available (node unreachable and no snapshot yet)", http.StatusNotFound)
+}
+
+func writeBalance(w http.ResponseWriter, address string, b BalanceSnapshot, live bool) {
+	out := map[string]any{
+		"address": address, "symbol": "ATOM", "date": b.Date.UTC().Format("2006-01-02"),
+		"liquid": b.Liquid, "staked": b.Staked, "reward": b.Reward,
+		"total": b.Liquid + b.Staked + b.Reward,
+	}
+	if live {
+		out["live"] = true
+	}
+	_ = json.NewEncoder(w).Encode(out)
+}

--- a/taxapi/constants.go
+++ b/taxapi/constants.go
@@ -1,0 +1,17 @@
+package taxapi
+
+// Row.Category and Row.Direction literals, shared across export, 8949 and row
+// building. The tax layer's classifications (tax.Category*) marshal to the same
+// strings; fee rows are built from the SDK's generic Fee table at export time,
+// so "fee" exists only on this side.
+const (
+	categoryReward     = "reward"
+	categoryCommission = "commission"
+	categoryFee        = "fee"
+	categoryNFTSale    = "nft_sale"
+	categoryNFTMint    = "nft_mint"
+	categorySwap       = "swap"
+
+	directionIn  = "in"
+	directionOut = "out"
+)

--- a/taxapi/export.go
+++ b/taxapi/export.go
@@ -23,12 +23,17 @@ type Row struct {
 	To        string
 	TxHash    string
 	Asset     string // non-fungible asset id "<collection>/<token_id>" for nft_sale
+	IsIBC     bool   // true when Denom is an IBC trace path (Symbol is the resolved base)
 }
 
-// description is the human/tax note; for NFT sales it names the asset sold.
+// description is the human/tax note; NFT sales name the asset, IBC rows carry the
+// raw trace path so the UI can show an "IBC" badge with full detail on hover.
 func (r Row) description() string {
 	if r.Category == "nft_sale" && r.Asset != "" {
 		return "nft_sale " + r.Asset
+	}
+	if r.IsIBC {
+		return "ibc " + r.Denom
 	}
 	return r.Category
 }

--- a/taxapi/export.go
+++ b/taxapi/export.go
@@ -30,8 +30,8 @@ type Row struct {
 // description is the human/tax note; NFT sales name the asset, IBC rows carry the
 // raw trace path so the UI can show an "IBC" badge with full detail on hover.
 func (r Row) description() string {
-	if r.Category == "nft_sale" && r.Asset != "" {
-		return "nft_sale " + r.Asset
+	if (r.Category == "nft_sale" || r.Category == "nft_mint") && r.Asset != "" {
+		return r.Category + " " + r.Asset
 	}
 	if r.IsIBC {
 		return "ibc " + r.Denom
@@ -46,8 +46,10 @@ func (r Row) label() string {
 		return "staking"
 	case "fee":
 		return "fee"
-	case "nft_sale":
+	case "nft_sale", "nft_mint":
 		return "nft"
+	case "swap":
+		return "swap"
 	default:
 		if r.Direction == "in" {
 			return "receive"
@@ -189,12 +191,14 @@ func ctcType(r Row) string {
 		return "staking"
 	case "fee":
 		return "fee"
-	case "nft_sale":
-		// Seller disposes the NFT (sell), buyer acquires it (buy).
+	case "nft_sale", "swap":
+		// Disposal leg = sell, acquisition leg = buy.
 		if r.Direction == "out" {
 			return "sell"
 		}
 		return "buy"
+	case "nft_mint":
+		return "buy" // acquisition
 	default:
 		if r.Direction == "in" {
 			return "receive"

--- a/taxapi/export.go
+++ b/taxapi/export.go
@@ -16,12 +16,21 @@ type Row struct {
 	Direction string // in | out
 	Symbol    string
 	Denom     string
-	Amount    decimal.Decimal // display units
+	Amount    decimal.Decimal // display units (for nft_sale: the sale price in Denom)
 	PriceUSD  decimal.Decimal // per unit at the event date (0 if unknown)
 	ValueUSD  decimal.Decimal // Amount * PriceUSD
 	From      string
 	To        string
 	TxHash    string
+	Asset     string // non-fungible asset id "<collection>/<token_id>" for nft_sale
+}
+
+// description is the human/tax note; for NFT sales it names the asset sold.
+func (r Row) description() string {
+	if r.Category == "nft_sale" && r.Asset != "" {
+		return "nft_sale " + r.Asset
+	}
+	return r.Category
 }
 
 // label maps our category to a human/tax label.
@@ -31,6 +40,8 @@ func (r Row) label() string {
 		return "staking"
 	case "fee":
 		return "fee"
+	case "nft_sale":
+		return "nft"
 	default:
 		if r.Direction == "in" {
 			return "receive"
@@ -52,7 +63,7 @@ func WriteCSV(out io.Writer, format string, rows []Row) error {
 			_ = w.Write([]string{
 				r.Time.UTC().Format("2006-01-02 15:04:05 UTC"),
 				sentAmt, sentCur, recvAmt, recvCur,
-				"", "", usd(r.ValueUSD), "USD", r.label(), r.Category, r.TxHash,
+				"", "", usd(r.ValueUSD), "USD", r.label(), r.description(), r.TxHash,
 			})
 		}
 
@@ -83,7 +94,7 @@ func WriteCSV(out io.Writer, format string, rows []Row) error {
 			}
 			_ = w.Write([]string{
 				r.Time.UTC().Format("2006-01-02 15:04:05"),
-				"Cosmos", sentCur, sentAmt, recvCur, recvAmt, "", "", typ, r.Category, r.TxHash,
+				"Cosmos", sentCur, sentAmt, recvCur, recvAmt, "", "", typ, r.description(), r.TxHash,
 			})
 		}
 
@@ -95,7 +106,7 @@ func WriteCSV(out io.Writer, format string, rows []Row) error {
 			_ = w.Write([]string{
 				r.Time.UTC().Format("2006-01-02 15:04:05"),
 				typ, r.Symbol, r.Amount.String(), "", "", "", "",
-				r.From, r.To, "cosmos", r.TxHash, r.Category, refPrice(r.PriceUSD), "USD",
+				r.From, r.To, "cosmos", r.TxHash, r.description(), refPrice(r.PriceUSD), "USD",
 			})
 		}
 
@@ -118,6 +129,12 @@ func ctcType(r Row) string {
 		return "staking"
 	case "fee":
 		return "fee"
+	case "nft_sale":
+		// Seller disposes the NFT (sell), buyer acquires it (buy).
+		if r.Direction == "out" {
+			return "sell"
+		}
+		return "buy"
 	default:
 		if r.Direction == "in" {
 			return "receive"

--- a/taxapi/export.go
+++ b/taxapi/export.go
@@ -30,7 +30,7 @@ type Row struct {
 // description is the human/tax note; NFT sales name the asset, IBC rows carry the
 // raw trace path so the UI can show an "IBC" badge with full detail on hover.
 func (r Row) description() string {
-	if (r.Category == "nft_sale" || r.Category == "nft_mint") && r.Asset != "" {
+	if (r.Category == categoryNFTSale || r.Category == categoryNFTMint) && r.Asset != "" {
 		return r.Category + " " + r.Asset
 	}
 	if r.IsIBC {
@@ -42,16 +42,16 @@ func (r Row) description() string {
 // label maps our category to a human/tax label.
 func (r Row) label() string {
 	switch r.Category {
-	case "reward", "commission":
+	case categoryReward, categoryCommission:
 		return "staking"
-	case "fee":
-		return "fee"
-	case "nft_sale", "nft_mint":
+	case categoryFee:
+		return categoryFee
+	case categoryNFTSale, categoryNFTMint:
 		return "nft"
-	case "swap":
-		return "swap"
+	case categorySwap:
+		return categorySwap
 	default:
-		if r.Direction == "in" {
+		if r.Direction == directionIn {
 			return "receive"
 		}
 		return "send"
@@ -80,7 +80,7 @@ func WriteCSV(out io.Writer, format string, rows []Row) error {
 		for _, r := range rows {
 			sentAmt, sentCur, recvAmt, recvCur := splitDir(r)
 			tag := ""
-			if r.Category == "reward" || r.Category == "commission" {
+			if r.Category == categoryReward || r.Category == categoryCommission {
 				tag = "staked"
 			}
 			_ = w.Write([]string{
@@ -94,10 +94,10 @@ func WriteCSV(out io.Writer, format string, rows []Row) error {
 		for _, r := range rows {
 			sentAmt, sentCur, recvAmt, recvCur := splitDir(r)
 			typ := "Deposit"
-			if r.Direction == "out" {
+			if r.Direction == directionOut {
 				typ = "Withdrawal"
 			}
-			if r.Category == "reward" || r.Category == "commission" {
+			if r.Category == categoryReward || r.Category == categoryCommission {
 				typ = "Staking Reward"
 			}
 			_ = w.Write([]string{
@@ -124,12 +124,12 @@ func WriteCSV(out io.Writer, format string, rows []Row) error {
 		for _, r := range rows {
 			date := r.Time.UTC().Format("2006-01-02 15:04:05")
 			amt, rate, val := r.Amount.String(), refPrice(r.PriceUSD), usd(r.ValueUSD)
-			if r.Direction == "in" && r.Category != "fee" {
+			if r.Direction == directionIn && r.Category != categoryFee {
 				_ = w.Write([]string{date, "deposit", r.TxHash, r.Symbol, amt, rate, val, "", "", "", "", "", "", "", "", party(r), r.description()})
 			} else {
 				ot := "withdraw"
-				if r.Category == "fee" {
-					ot = "fee"
+				if r.Category == categoryFee {
+					ot = categoryFee
 				}
 				_ = w.Write([]string{date, ot, r.TxHash, "", "", "", "", r.Symbol, amt, rate, val, "", "", "", "", party(r), r.description()})
 			}
@@ -140,10 +140,10 @@ func WriteCSV(out io.Writer, format string, rows []Row) error {
 		_ = w.Write([]string{"id", "date", "type", "amount", "amountTicker", "txHash", "contactAddress", "category"})
 		for i, r := range rows {
 			typ := "Deposit"
-			if r.Direction == "out" {
+			if r.Direction == directionOut {
 				typ = "Withdrawal"
 			}
-			if r.Category == "fee" {
+			if r.Category == categoryFee {
 				typ = "Fee"
 			}
 			_ = w.Write([]string{
@@ -172,14 +172,14 @@ func WriteCSV(out io.Writer, format string, rows []Row) error {
 
 // party returns the counterparty address for a row (the non-fee side).
 func party(r Row) string {
-	if r.Direction == "in" {
+	if r.Direction == directionIn {
 		return r.From
 	}
 	return r.To
 }
 
 func splitDir(r Row) (sentAmt, sentCur, recvAmt, recvCur string) {
-	if r.Direction == "out" {
+	if r.Direction == directionOut {
 		return r.Amount.String(), r.Symbol, "", ""
 	}
 	return "", "", r.Amount.String(), r.Symbol
@@ -187,20 +187,20 @@ func splitDir(r Row) (sentAmt, sentCur, recvAmt, recvCur string) {
 
 func ctcType(r Row) string {
 	switch r.Category {
-	case "reward", "commission":
+	case categoryReward, categoryCommission:
 		return "staking"
-	case "fee":
-		return "fee"
-	case "nft_sale", "swap":
+	case categoryFee:
+		return categoryFee
+	case categoryNFTSale, categorySwap:
 		// Disposal leg = sell, acquisition leg = buy.
-		if r.Direction == "out" {
+		if r.Direction == directionOut {
 			return "sell"
 		}
 		return "buy"
-	case "nft_mint":
+	case categoryNFTMint:
 		return "buy" // acquisition
 	default:
-		if r.Direction == "in" {
+		if r.Direction == directionIn {
 			return "receive"
 		}
 		return "send"

--- a/taxapi/export.go
+++ b/taxapi/export.go
@@ -1,0 +1,141 @@
+package taxapi
+
+import (
+	"encoding/csv"
+	"io"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Row is a normalized, priced taxable event from the queried address's point of
+// view (Direction = in|out). Platform exporters map this to their columns.
+type Row struct {
+	Time      time.Time
+	Category  string // transfer | reward | commission | ibc_in | ibc_out | fee
+	Direction string // in | out
+	Symbol    string
+	Denom     string
+	Amount    decimal.Decimal // display units
+	PriceUSD  decimal.Decimal // per unit at the event date (0 if unknown)
+	ValueUSD  decimal.Decimal // Amount * PriceUSD
+	From      string
+	To        string
+	TxHash    string
+}
+
+// label maps our category to a human/tax label.
+func (r Row) label() string {
+	switch r.Category {
+	case "reward", "commission":
+		return "staking"
+	case "fee":
+		return "fee"
+	default:
+		if r.Direction == "in" {
+			return "receive"
+		}
+		return "send"
+	}
+}
+
+// WriteCSV writes rows in the requested platform format.
+func WriteCSV(out io.Writer, format string, rows []Row) error {
+	w := csv.NewWriter(out)
+	defer w.Flush()
+
+	switch format {
+	case "koinly":
+		_ = w.Write([]string{"Date", "Sent Amount", "Sent Currency", "Received Amount", "Received Currency", "Fee Amount", "Fee Currency", "Net Worth Amount", "Net Worth Currency", "Label", "Description", "TxHash"})
+		for _, r := range rows {
+			sentAmt, sentCur, recvAmt, recvCur := splitDir(r)
+			_ = w.Write([]string{
+				r.Time.UTC().Format("2006-01-02 15:04:05 UTC"),
+				sentAmt, sentCur, recvAmt, recvCur,
+				"", "", usd(r.ValueUSD), "USD", r.label(), r.Category, r.TxHash,
+			})
+		}
+
+	case "cointracker":
+		_ = w.Write([]string{"Date", "Received Quantity", "Received Currency", "Sent Quantity", "Sent Currency", "Fee Amount", "Fee Currency", "Tag"})
+		for _, r := range rows {
+			sentAmt, sentCur, recvAmt, recvCur := splitDir(r)
+			tag := ""
+			if r.Category == "reward" || r.Category == "commission" {
+				tag = "staked"
+			}
+			_ = w.Write([]string{
+				r.Time.UTC().Format("01/02/2006 15:04:05"),
+				recvAmt, recvCur, sentAmt, sentCur, "", "", tag,
+			})
+		}
+
+	case "coinledger":
+		_ = w.Write([]string{"Date (UTC)", "Platform", "Asset Sent", "Amount Sent", "Asset Received", "Amount Received", "Fee Currency", "Fee Amount", "Type", "Description", "TxHash"})
+		for _, r := range rows {
+			sentAmt, sentCur, recvAmt, recvCur := splitDir(r)
+			typ := "Deposit"
+			if r.Direction == "out" {
+				typ = "Withdrawal"
+			}
+			if r.Category == "reward" || r.Category == "commission" {
+				typ = "Staking Reward"
+			}
+			_ = w.Write([]string{
+				r.Time.UTC().Format("2006-01-02 15:04:05"),
+				"Cosmos", sentCur, sentAmt, recvCur, recvAmt, "", "", typ, r.Category, r.TxHash,
+			})
+		}
+
+	case "summ", "cryptotaxcalculator":
+		// Richest format: carries our oracle reference price per unit.
+		_ = w.Write([]string{"Timestamp (UTC)", "Type", "Base Currency", "Base Amount", "Quote Currency (Optional)", "Quote Amount (Optional)", "Fee Currency (Optional)", "Fee Amount (Optional)", "From (Optional)", "To (Optional)", "Blockchain (Optional)", "ID (Optional)", "Description (Optional)", "Reference Price Per Unit (Optional)", "Reference Price Currency (Optional)"}) //nolint:lll
+		for _, r := range rows {
+			typ := ctcType(r)
+			_ = w.Write([]string{
+				r.Time.UTC().Format("2006-01-02 15:04:05"),
+				typ, r.Symbol, r.Amount.String(), "", "", "", "",
+				r.From, r.To, "cosmos", r.TxHash, r.Category, refPrice(r.PriceUSD), "USD",
+			})
+		}
+
+	default: // fall through to koinly for unknown formats
+		return WriteCSV(out, "koinly", rows)
+	}
+	return w.Error()
+}
+
+func splitDir(r Row) (sentAmt, sentCur, recvAmt, recvCur string) {
+	if r.Direction == "out" {
+		return r.Amount.String(), r.Symbol, "", ""
+	}
+	return "", "", r.Amount.String(), r.Symbol
+}
+
+func ctcType(r Row) string {
+	switch r.Category {
+	case "reward", "commission":
+		return "staking"
+	case "fee":
+		return "fee"
+	default:
+		if r.Direction == "in" {
+			return "receive"
+		}
+		return "send"
+	}
+}
+
+func usd(d decimal.Decimal) string {
+	if d.IsZero() {
+		return ""
+	}
+	return d.StringFixed(2)
+}
+
+func refPrice(d decimal.Decimal) string {
+	if d.IsZero() {
+		return ""
+	}
+	return d.String()
+}

--- a/taxapi/export.go
+++ b/taxapi/export.go
@@ -2,6 +2,7 @@ package taxapi
 
 import (
 	"encoding/csv"
+	"fmt"
 	"io"
 	"time"
 
@@ -115,10 +116,64 @@ func WriteCSV(out io.Writer, format string, rows []Row) error {
 			})
 		}
 
+	case "cryptio":
+		// Cryptio custom-CSV template (enterprise sub-ledger). Strict schema.
+		_ = w.Write([]string{"transactionDate", "orderType", "txhash", "incomingAsset", "incomingVolume", "incomingUnitRate", "incomingTransactionValue", "outgoingAsset", "outgoingVolume", "outgoingUnitRate", "outgoingTransactionValue", "feeAsset", "feeVolume", "feeUnitRate", "feeTransactionValue", "otherParties", "note"}) //nolint:lll
+		for _, r := range rows {
+			date := r.Time.UTC().Format("2006-01-02 15:04:05")
+			amt, rate, val := r.Amount.String(), refPrice(r.PriceUSD), usd(r.ValueUSD)
+			if r.Direction == "in" && r.Category != "fee" {
+				_ = w.Write([]string{date, "deposit", r.TxHash, r.Symbol, amt, rate, val, "", "", "", "", "", "", "", "", party(r), r.description()})
+			} else {
+				ot := "withdraw"
+				if r.Category == "fee" {
+					ot = "fee"
+				}
+				_ = w.Write([]string{date, ot, r.TxHash, "", "", "", "", r.Symbol, amt, rate, val, "", "", "", "", party(r), r.description()})
+			}
+		}
+
+	case "bitwave":
+		// Bitwave enterprise accounting; core columns + a unique id per line.
+		_ = w.Write([]string{"id", "date", "type", "amount", "amountTicker", "txHash", "contactAddress", "category"})
+		for i, r := range rows {
+			typ := "Deposit"
+			if r.Direction == "out" {
+				typ = "Withdrawal"
+			}
+			if r.Category == "fee" {
+				typ = "Fee"
+			}
+			_ = w.Write([]string{
+				fmt.Sprintf("%s-%d", r.TxHash, i), r.Time.UTC().Format(time.RFC3339),
+				typ, r.Amount.String(), r.Symbol, r.TxHash, party(r), r.description(),
+			})
+		}
+
+	case "generic":
+		// Universal, fully-typed enterprise CSV: every field, USD basis. Any tool
+		// or accountant can map it; also the recommended import for Trace Finance.
+		_ = w.Write([]string{"date_utc", "tx_hash", "category", "direction", "asset", "denom", "amount", "unit_price_usd", "value_usd", "from", "to", "nft_asset", "chain"}) //nolint:lll
+		for _, r := range rows {
+			_ = w.Write([]string{
+				r.Time.UTC().Format(time.RFC3339), r.TxHash, r.Category, r.Direction,
+				r.Symbol, r.Denom, r.Amount.String(), refPrice(r.PriceUSD), usd(r.ValueUSD),
+				r.From, r.To, r.Asset, "cosmoshub-4",
+			})
+		}
+
 	default: // fall through to koinly for unknown formats
 		return WriteCSV(out, "koinly", rows)
 	}
 	return w.Error()
+}
+
+// party returns the counterparty address for a row (the non-fee side).
+func party(r Row) string {
+	if r.Direction == "in" {
+		return r.From
+	}
+	return r.To
 }
 
 func splitDir(r Row) (sentAmt, sentCur, recvAmt, recvCur string) {

--- a/taxapi/form8949.go
+++ b/taxapi/form8949.go
@@ -48,19 +48,19 @@ func Build8949(rows []Row) []Form8949Row {
 
 	for _, r := range sorted {
 		// NFT acquisition via mint: establishes the NFT's cost basis.
-		if r.Category == "nft_mint" {
+		if r.Category == categoryNFTMint {
 			nftLots[r.Asset] = append(nftLots[r.Asset], lot{qty: decimal.NewFromInt(1), cost: r.ValueUSD, date: r.Time})
 			continue
 		}
 
 		// NFT marketplace sale: dispose/acquire the NFT, valued in USD.
-		if r.Category == "nft_sale" {
+		if r.Category == categoryNFTSale {
 			key := r.Asset
 			desc := "NFT " + r.Asset
 			switch r.Direction {
-			case "in": // buyer acquires the NFT; basis = USD paid
+			case directionIn: // buyer acquires the NFT; basis = USD paid
 				nftLots[key] = append(nftLots[key], lot{qty: decimal.NewFromInt(1), cost: r.ValueUSD, date: r.Time})
-			case "out": // seller disposes the NFT; proceeds = USD received
+			case directionOut: // seller disposes the NFT; proceeds = USD received
 				proceeds := r.ValueUSD
 				q := nftLots[key]
 				if len(q) == 0 {
@@ -95,11 +95,11 @@ func Build8949(rows []Row) []Form8949Row {
 			asset = r.Denom
 		}
 		switch {
-		case r.Direction == "in" && r.Category != "fee":
+		case r.Direction == directionIn && r.Category != categoryFee:
 			// acquisition
 			lots[asset] = append(lots[asset], lot{qty: r.Amount, cost: r.PriceUSD, date: r.Time})
 
-		case r.Direction == "out":
+		case r.Direction == directionOut:
 			// disposal (incl. fee spends): consume FIFO
 			remaining := r.Amount
 			disposalPrice := r.PriceUSD

--- a/taxapi/form8949.go
+++ b/taxapi/form8949.go
@@ -31,15 +31,59 @@ type lot struct {
 // per disposal lot consumed. NOTE: this is a basic engine — cost basis for
 // units acquired before the queried window is unknown (treated as 0 / "Various");
 // accurate basis needs full acquisition history (archive-node indexing).
+//
+// NFT marketplace sales (Category "nft_sale") are treated as dispositions of the
+// non-fungible asset itself, NOT of the ATOM that changed hands: a buy (in)
+// establishes the NFT's USD cost basis, a sell (out) is a capital disposal with
+// proceeds = the sale's USD value. (The ATOM leg of an NFT trade is a separate,
+// second-order disposal not yet modeled; the headline NFT gain/loss is.)
 func Build8949(rows []Row) []Form8949Row {
 	sorted := make([]Row, len(rows))
 	copy(sorted, rows)
 	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Time.Before(sorted[j].Time) })
 
-	lots := map[string][]lot{} // asset -> FIFO lots
+	lots := map[string][]lot{}    // asset -> FIFO lots (fungible)
+	nftLots := map[string][]lot{} // "<collection>/<token>" -> FIFO lots (qty always 1, cost in total USD)
 	var out []Form8949Row
 
 	for _, r := range sorted {
+		// NFT marketplace sale: dispose/acquire the NFT, valued in USD.
+		if r.Category == "nft_sale" {
+			key := r.Asset
+			desc := "NFT " + r.Asset
+			switch r.Direction {
+			case "in": // buyer acquires the NFT; basis = USD paid
+				nftLots[key] = append(nftLots[key], lot{qty: decimal.NewFromInt(1), cost: r.ValueUSD, date: r.Time})
+			case "out": // seller disposes the NFT; proceeds = USD received
+				proceeds := r.ValueUSD
+				q := nftLots[key]
+				if len(q) == 0 {
+					out = append(out, Form8949Row{
+						Description:  desc,
+						DateAcquired: "Various",
+						DateSold:     r.Time.UTC().Format("01/02/2006"),
+						Proceeds:     proceeds,
+						CostBasis:    decimal.Zero,
+						GainLoss:     proceeds,
+						LongTerm:     false,
+					})
+				} else {
+					l := q[0]
+					out = append(out, Form8949Row{
+						Description:  desc,
+						DateAcquired: l.date.UTC().Format("01/02/2006"),
+						DateSold:     r.Time.UTC().Format("01/02/2006"),
+						Proceeds:     proceeds,
+						CostBasis:    l.cost,
+						GainLoss:     proceeds.Sub(l.cost),
+						LongTerm:     r.Time.Sub(l.date) > 365*24*time.Hour,
+					})
+					nftLots[key] = q[1:]
+				}
+			}
+			continue
+		}
+
 		asset := r.Symbol
 		if asset == "" {
 			asset = r.Denom

--- a/taxapi/form8949.go
+++ b/taxapi/form8949.go
@@ -154,7 +154,7 @@ type ScheduleD struct {
 	LongTermProceeds   decimal.Decimal `json:"long_term_proceeds"`
 	LongTermCostBasis  decimal.Decimal `json:"long_term_cost_basis"`
 	LongTermGainLoss   decimal.Decimal `json:"long_term_gain_loss"` // Schedule D line 15
-	NetGainLoss        decimal.Decimal `json:"net_gain_loss"`        // Schedule D line 16
+	NetGainLoss        decimal.Decimal `json:"net_gain_loss"`       // Schedule D line 16
 }
 
 // BuildScheduleD rolls up 8949 lines into the Schedule D short/long-term totals.

--- a/taxapi/form8949.go
+++ b/taxapi/form8949.go
@@ -94,6 +94,37 @@ func Build8949(rows []Row) []Form8949Row {
 	return out
 }
 
+// ScheduleD is the capital-gains summary that the 8949 totals flow into on IRS
+// Schedule D (Form 1040). Short-term and long-term are taxed differently, so they
+// stay separate; Net is line 16 (overall capital gain or loss).
+type ScheduleD struct {
+	ShortTermProceeds  decimal.Decimal `json:"short_term_proceeds"`
+	ShortTermCostBasis decimal.Decimal `json:"short_term_cost_basis"`
+	ShortTermGainLoss  decimal.Decimal `json:"short_term_gain_loss"` // Schedule D line 7
+	LongTermProceeds   decimal.Decimal `json:"long_term_proceeds"`
+	LongTermCostBasis  decimal.Decimal `json:"long_term_cost_basis"`
+	LongTermGainLoss   decimal.Decimal `json:"long_term_gain_loss"` // Schedule D line 15
+	NetGainLoss        decimal.Decimal `json:"net_gain_loss"`        // Schedule D line 16
+}
+
+// BuildScheduleD rolls up 8949 lines into the Schedule D short/long-term totals.
+func BuildScheduleD(rows []Form8949Row) ScheduleD {
+	var d ScheduleD
+	for _, r := range rows {
+		if r.LongTerm {
+			d.LongTermProceeds = d.LongTermProceeds.Add(r.Proceeds)
+			d.LongTermCostBasis = d.LongTermCostBasis.Add(r.CostBasis)
+			d.LongTermGainLoss = d.LongTermGainLoss.Add(r.GainLoss)
+		} else {
+			d.ShortTermProceeds = d.ShortTermProceeds.Add(r.Proceeds)
+			d.ShortTermCostBasis = d.ShortTermCostBasis.Add(r.CostBasis)
+			d.ShortTermGainLoss = d.ShortTermGainLoss.Add(r.GainLoss)
+		}
+	}
+	d.NetGainLoss = d.ShortTermGainLoss.Add(d.LongTermGainLoss)
+	return d
+}
+
 // Write8949CSV writes the 8949 rows, short-term first then long-term, matching
 // the Part I / Part II split.
 func Write8949CSV(out io.Writer, rows []Form8949Row) error {

--- a/taxapi/form8949.go
+++ b/taxapi/form8949.go
@@ -47,6 +47,12 @@ func Build8949(rows []Row) []Form8949Row {
 	var out []Form8949Row
 
 	for _, r := range sorted {
+		// NFT acquisition via mint: establishes the NFT's cost basis.
+		if r.Category == "nft_mint" {
+			nftLots[r.Asset] = append(nftLots[r.Asset], lot{qty: decimal.NewFromInt(1), cost: r.ValueUSD, date: r.Time})
+			continue
+		}
+
 		// NFT marketplace sale: dispose/acquire the NFT, valued in USD.
 		if r.Category == "nft_sale" {
 			key := r.Asset

--- a/taxapi/form8949.go
+++ b/taxapi/form8949.go
@@ -1,0 +1,114 @@
+package taxapi
+
+import (
+	"encoding/csv"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Form8949Row is one disposal line for IRS Form 8949 (Sales and Other
+// Dispositions of Capital Assets).
+type Form8949Row struct {
+	Description  string // e.g. "1.5 ATOM"
+	DateAcquired string // MM/DD/YYYY or "Various"
+	DateSold     string // MM/DD/YYYY
+	Proceeds     decimal.Decimal
+	CostBasis    decimal.Decimal
+	GainLoss     decimal.Decimal
+	LongTerm     bool
+}
+
+type lot struct {
+	qty  decimal.Decimal // display units
+	cost decimal.Decimal // USD per unit
+	date time.Time
+}
+
+// Build8949 runs a per-asset FIFO over the priced rows and emits one 8949 line
+// per disposal lot consumed. NOTE: this is a basic engine — cost basis for
+// units acquired before the queried window is unknown (treated as 0 / "Various");
+// accurate basis needs full acquisition history (archive-node indexing).
+func Build8949(rows []Row) []Form8949Row {
+	sorted := make([]Row, len(rows))
+	copy(sorted, rows)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Time.Before(sorted[j].Time) })
+
+	lots := map[string][]lot{} // asset -> FIFO lots
+	var out []Form8949Row
+
+	for _, r := range sorted {
+		asset := r.Symbol
+		if asset == "" {
+			asset = r.Denom
+		}
+		switch {
+		case r.Direction == "in" && r.Category != "fee":
+			// acquisition
+			lots[asset] = append(lots[asset], lot{qty: r.Amount, cost: r.PriceUSD, date: r.Time})
+
+		case r.Direction == "out":
+			// disposal (incl. fee spends): consume FIFO
+			remaining := r.Amount
+			disposalPrice := r.PriceUSD
+			for remaining.IsPositive() {
+				q := lots[asset]
+				if len(q) == 0 {
+					// no known lot: basis unknown
+					proceeds := remaining.Mul(disposalPrice)
+					out = append(out, Form8949Row{
+						Description:  remaining.String() + " " + asset,
+						DateAcquired: "Various",
+						DateSold:     r.Time.UTC().Format("01/02/2006"),
+						Proceeds:     proceeds,
+						CostBasis:    decimal.Zero,
+						GainLoss:     proceeds,
+						LongTerm:     false,
+					})
+					break
+				}
+				l := q[0]
+				take := decimal.Min(remaining, l.qty)
+				proceeds := take.Mul(disposalPrice)
+				cost := take.Mul(l.cost)
+				out = append(out, Form8949Row{
+					Description:  take.String() + " " + asset,
+					DateAcquired: l.date.UTC().Format("01/02/2006"),
+					DateSold:     r.Time.UTC().Format("01/02/2006"),
+					Proceeds:     proceeds,
+					CostBasis:    cost,
+					GainLoss:     proceeds.Sub(cost),
+					LongTerm:     r.Time.Sub(l.date) > 365*24*time.Hour,
+				})
+				remaining = remaining.Sub(take)
+				if l.qty.Equal(take) {
+					lots[asset] = q[1:]
+				} else {
+					q[0].qty = l.qty.Sub(take)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// Write8949CSV writes the 8949 rows, short-term first then long-term, matching
+// the Part I / Part II split.
+func Write8949CSV(out io.Writer, rows []Form8949Row) error {
+	w := csv.NewWriter(out)
+	defer w.Flush()
+	_ = w.Write([]string{"Part", "Description of property", "Date acquired", "Date sold", "Proceeds (USD)", "Cost basis (USD)", "Gain or loss (USD)"})
+	write := func(part string, longTerm bool) {
+		for _, r := range rows {
+			if r.LongTerm != longTerm {
+				continue
+			}
+			_ = w.Write([]string{part, r.Description, r.DateAcquired, r.DateSold, r.Proceeds.StringFixed(2), r.CostBasis.StringFixed(2), r.GainLoss.StringFixed(2)})
+		}
+	}
+	write("I (short-term)", false)
+	write("II (long-term)", true)
+	return w.Error()
+}

--- a/taxapi/form8949_test.go
+++ b/taxapi/form8949_test.go
@@ -1,0 +1,47 @@
+package taxapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func d(i int64) decimal.Decimal { return decimal.NewFromInt(i) }
+
+func TestBuild8949FIFOGain(t *testing.T) {
+	day1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	day10 := day1.AddDate(0, 0, 10)
+	rows := []Row{
+		{Time: day1, Direction: "in", Category: "transfer", Symbol: "ATOM", Amount: d(10), PriceUSD: d(2)},
+		{Time: day10, Direction: "out", Category: "transfer", Symbol: "ATOM", Amount: d(4), PriceUSD: d(3)},
+	}
+	got := Build8949(rows)
+	if len(got) != 1 {
+		t.Fatalf("want 1 disposal, got %d: %+v", len(got), got)
+	}
+	r := got[0]
+	if !r.Proceeds.Equal(d(12)) || !r.CostBasis.Equal(d(8)) || !r.GainLoss.Equal(d(4)) || r.LongTerm {
+		t.Fatalf("wrong 8949 calc: %+v", r)
+	}
+}
+
+func TestBuild8949LongTermAndUnknownBasis(t *testing.T) {
+	buy := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	sell := buy.AddDate(1, 0, 1) // >365d → long term
+	rows := []Row{
+		{Time: buy, Direction: "in", Category: "reward", Symbol: "ATOM", Amount: d(5), PriceUSD: d(2)},
+		{Time: sell, Direction: "out", Category: "transfer", Symbol: "ATOM", Amount: d(8), PriceUSD: d(4)},
+	}
+	got := Build8949(rows)
+	// 5 from the lot (long-term) + 3 with unknown basis
+	if len(got) != 2 {
+		t.Fatalf("want 2 lines, got %d: %+v", len(got), got)
+	}
+	if !got[0].LongTerm || !got[0].CostBasis.Equal(d(10)) || !got[0].Proceeds.Equal(d(20)) {
+		t.Fatalf("lot line wrong: %+v", got[0])
+	}
+	if got[1].DateAcquired != "Various" || !got[1].CostBasis.IsZero() || !got[1].Proceeds.Equal(d(12)) {
+		t.Fatalf("unknown-basis line wrong: %+v", got[1])
+	}
+}

--- a/taxapi/form8949_test.go
+++ b/taxapi/form8949_test.go
@@ -26,6 +26,35 @@ func TestBuild8949FIFOGain(t *testing.T) {
 	}
 }
 
+func TestBuild8949NFTSale(t *testing.T) {
+	buy := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sell := buy.AddDate(0, 0, 10)
+	rows := []Row{
+		// Bought NFT for ~$2, sold for ~$3 → short-term gain $1 on the NFT itself.
+		{Time: buy, Direction: "in", Category: "nft_sale", Asset: "coll/42", ValueUSD: d(2)},
+		{Time: sell, Direction: "out", Category: "nft_sale", Asset: "coll/42", ValueUSD: d(3)},
+	}
+	got := Build8949(rows)
+	if len(got) != 1 {
+		t.Fatalf("want 1 disposal, got %d: %+v", len(got), got)
+	}
+	r := got[0]
+	if r.Description != "NFT coll/42" || !r.Proceeds.Equal(d(3)) || !r.CostBasis.Equal(d(2)) ||
+		!r.GainLoss.Equal(d(1)) || r.LongTerm {
+		t.Fatalf("nft 8949 calc wrong: %+v", r)
+	}
+}
+
+// An NFT sold without a recorded prior buy has unknown ("Various") basis.
+func TestBuild8949NFTUnknownBasis(t *testing.T) {
+	sell := time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC)
+	rows := []Row{{Time: sell, Direction: "out", Category: "nft_sale", Asset: "coll/7", ValueUSD: d(5)}}
+	got := Build8949(rows)
+	if len(got) != 1 || got[0].DateAcquired != "Various" || !got[0].CostBasis.IsZero() || !got[0].Proceeds.Equal(d(5)) {
+		t.Fatalf("nft unknown-basis wrong: %+v", got)
+	}
+}
+
 func TestBuild8949LongTermAndUnknownBasis(t *testing.T) {
 	buy := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	sell := buy.AddDate(1, 0, 1) // >365d → long term

--- a/taxapi/form990t.go
+++ b/taxapi/form990t.go
@@ -1,0 +1,83 @@
+package taxapi
+
+import "github.com/shopspring/decimal"
+
+// Form 990-T / UBIT computation for staking income earned inside a tax-advantaged
+// account (IRA/HSA/Solo-401k). Staking rewards are treated here as unrelated
+// business taxable income (UBTI); whether staking is UBTI is a contested area, so
+// this is a conservative estimate, not advice. An IRA is a trust, so 990-T tax is
+// computed at trust rates after the $1,000 specific deduction. No 990-T filing is
+// required when gross UBTI is under $1,000.
+
+// SpecificDeduction is the §512(b)(12) specific deduction.
+var specificDeduction = decimal.NewFromInt(1000)
+
+// trustBracket is a marginal tax bracket.
+type trustBracket struct {
+	upTo decimal.Decimal // upper bound of the bracket (zero value = no cap)
+	rate decimal.Decimal
+}
+
+// 2024 trust/estate brackets (inflation-adjusted yearly; used as the estimate).
+func trustBrackets() []trustBracket {
+	d := decimal.NewFromInt
+	pct := func(p int64) decimal.Decimal { return decimal.NewFromInt(p).Div(decimal.NewFromInt(100)) }
+	return []trustBracket{
+		{upTo: d(3100), rate: pct(10)},
+		{upTo: d(11150), rate: pct(24)},
+		{upTo: d(15200), rate: pct(35)},
+		{upTo: decimal.Zero, rate: pct(37)}, // top, no cap
+	}
+}
+
+// Form990T is the UBIT summary for an entity's staking income.
+type Form990T struct {
+	StakingIncomeUSD string `json:"staking_income_usd"` // gross UBTI
+	SpecificDeduction string `json:"specific_deduction"`
+	TaxableUBTI      string `json:"taxable_ubti_usd"`
+	EstimatedTaxUSD  string `json:"estimated_tax_usd"`
+	FilingRequired   bool   `json:"filing_required"` // gross UBTI >= $1,000
+	Note             string `json:"note"`
+}
+
+// compute990T runs the UBIT calc over a gross UBTI (USD).
+func compute990T(ubti decimal.Decimal) Form990T {
+	taxable := ubti.Sub(specificDeduction)
+	if taxable.IsNegative() {
+		taxable = decimal.Zero
+	}
+	tax := trustTax(taxable)
+	return Form990T{
+		StakingIncomeUSD:  ubti.StringFixed(2),
+		SpecificDeduction: specificDeduction.StringFixed(2),
+		TaxableUBTI:       taxable.StringFixed(2),
+		EstimatedTaxUSD:   tax.StringFixed(2),
+		FilingRequired:    ubti.GreaterThanOrEqual(specificDeduction),
+		Note:              "Estimate only. Staking as UBTI is unsettled; tax computed at 2024 trust rates after the $1,000 deduction.",
+	}
+}
+
+// trustTax applies the marginal trust brackets to a taxable amount.
+func trustTax(taxable decimal.Decimal) decimal.Decimal {
+	if !taxable.IsPositive() {
+		return decimal.Zero
+	}
+	tax := decimal.Zero
+	lower := decimal.Zero
+	for _, b := range trustBrackets() {
+		var top decimal.Decimal
+		if b.upTo.IsZero() {
+			top = taxable // top bracket, no cap
+		} else {
+			top = decimal.Min(taxable, b.upTo)
+		}
+		if top.GreaterThan(lower) {
+			tax = tax.Add(top.Sub(lower).Mul(b.rate))
+		}
+		lower = b.upTo
+		if !b.upTo.IsZero() && taxable.LessThanOrEqual(b.upTo) {
+			break
+		}
+	}
+	return tax
+}

--- a/taxapi/form990t.go
+++ b/taxapi/form990t.go
@@ -32,12 +32,12 @@ func trustBrackets() []trustBracket {
 
 // Form990T is the UBIT summary for an entity's staking income.
 type Form990T struct {
-	StakingIncomeUSD string `json:"staking_income_usd"` // gross UBTI
+	StakingIncomeUSD  string `json:"staking_income_usd"` // gross UBTI
 	SpecificDeduction string `json:"specific_deduction"`
-	TaxableUBTI      string `json:"taxable_ubti_usd"`
-	EstimatedTaxUSD  string `json:"estimated_tax_usd"`
-	FilingRequired   bool   `json:"filing_required"` // gross UBTI >= $1,000
-	Note             string `json:"note"`
+	TaxableUBTI       string `json:"taxable_ubti_usd"`
+	EstimatedTaxUSD   string `json:"estimated_tax_usd"`
+	FilingRequired    bool   `json:"filing_required"` // gross UBTI >= $1,000
+	Note              string `json:"note"`
 }
 
 // compute990T runs the UBIT calc over a gross UBTI (USD).

--- a/taxapi/form990t_test.go
+++ b/taxapi/form990t_test.go
@@ -1,0 +1,20 @@
+package taxapi
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestCompute990T(t *testing.T) {
+	// Under the $1,000 threshold: no filing, no tax.
+	low := compute990T(decimal.NewFromInt(800))
+	if low.FilingRequired || low.EstimatedTaxUSD != "0.00" || low.TaxableUBTI != "0.00" {
+		t.Fatalf("under-threshold wrong: %+v", low)
+	}
+	// $5,000 UBTI: taxable = 4,000; trust tax = 3100*10% + 900*24% = 310 + 216 = 526.
+	hi := compute990T(decimal.NewFromInt(5000))
+	if !hi.FilingRequired || hi.TaxableUBTI != "4000.00" || hi.EstimatedTaxUSD != "526.00" {
+		t.Fatalf("over-threshold wrong: %+v", hi)
+	}
+}

--- a/taxapi/ibc_test.go
+++ b/taxapi/ibc_test.go
@@ -1,0 +1,24 @@
+package taxapi
+
+import "testing"
+
+func TestIBCBaseDenom(t *testing.T) {
+	cases := []struct {
+		in    string
+		base  string
+		isIBC bool
+	}{
+		{"transfer/channel-0/uatom", "uatom", true},
+		{"transfer/channel-1/uatom", "uatom", true},
+		{"transfer/channel-0/transfer/08-wasm-1369/0xabc", "0xabc", true},
+		{"transfer/channel-0/factory/cosmos1xyz/ustars", "factory/cosmos1xyz/ustars", true},
+		{"uatom", "uatom", false},
+		{"ibc/ABC123", "ibc/ABC123", false},
+	}
+	for _, c := range cases {
+		base, isIBC := ibcBaseDenom(c.in)
+		if base != c.base || isIBC != c.isIBC {
+			t.Fatalf("ibcBaseDenom(%q) = (%q,%v), want (%q,%v)", c.in, base, isIBC, c.base, c.isIBC)
+		}
+	}
+}

--- a/taxapi/metrics.go
+++ b/taxapi/metrics.go
@@ -1,0 +1,38 @@
+package taxapi
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// handleMetrics exposes tax-indexer freshness in the Prometheus text exposition
+// format (stdlib-only, no client_golang). One instance indexes one chain, so the
+// metrics are unlabeled; Prometheus adds the pod/instance labels on scrape.
+func (s *Server) handleMetrics(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+	var res struct {
+		MaxHeight int64
+		MaxTime   *time.Time
+		NumBlocks int64
+	}
+	// Best-effort: on error the values stay zero and the endpoint still responds.
+	_ = s.db.Raw("SELECT MAX(height) AS max_height, MAX(time_stamp) AS max_time, COUNT(*) AS num_blocks FROM blocks").Scan(&res).Error
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# HELP taxindexer_latest_block_height Highest block height indexed\n# TYPE taxindexer_latest_block_height gauge\ntaxindexer_latest_block_height %d\n", res.MaxHeight)
+	fmt.Fprintf(&b, "# HELP taxindexer_blocks_indexed Total blocks indexed\n# TYPE taxindexer_blocks_indexed gauge\ntaxindexer_blocks_indexed %d\n", res.NumBlocks)
+
+	age := -1.0
+	ts := 0.0
+	if res.MaxTime != nil && !res.MaxTime.IsZero() {
+		age = time.Since(*res.MaxTime).Seconds()
+		ts = float64(res.MaxTime.Unix())
+	}
+	fmt.Fprintf(&b, "# HELP taxindexer_latest_block_time_seconds Unix time of the newest indexed block\n# TYPE taxindexer_latest_block_time_seconds gauge\ntaxindexer_latest_block_time_seconds %.0f\n", ts)
+	fmt.Fprintf(&b, "# HELP taxindexer_data_age_seconds Seconds since the newest indexed block's time (-1 if none)\n# TYPE taxindexer_data_age_seconds gauge\ntaxindexer_data_age_seconds %.0f\n", age)
+
+	_, _ = w.Write([]byte(b.String()))
+}

--- a/taxapi/price.go
+++ b/taxapi/price.go
@@ -1,0 +1,95 @@
+// Package taxapi serves taxable-event queries + exports (CSV for the major tax
+// platforms, plus a basic IRS 8949) over the data the tax indexer writes,
+// enriched with USD pricing + denom resolution from the wasm-indexer oracle.
+package taxapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// DenomMeta is the symbol + decimals for a base denom, from the oracle's
+// /denoms endpoint (chain-registry + scraped IBC traces).
+type DenomMeta struct {
+	Symbol   string
+	Decimals int
+}
+
+// Oracle is a thin client for the wasm-indexer price/denom API.
+type Oracle struct {
+	base string
+	http *http.Client
+
+	mu     sync.Mutex
+	denoms map[string]map[string]DenomMeta // chain -> denom -> meta (cached)
+	at     map[string]time.Time
+}
+
+func NewOracle(base string) *Oracle {
+	return &Oracle{
+		base:   base,
+		http:   &http.Client{Timeout: 8 * time.Second},
+		denoms: map[string]map[string]DenomMeta{},
+		at:     map[string]time.Time{},
+	}
+}
+
+// Denoms returns the chain's denom->meta map, cached for 1h.
+func (o *Oracle) Denoms(chain string) map[string]DenomMeta {
+	o.mu.Lock()
+	if m, ok := o.denoms[chain]; ok && time.Since(o.at[chain]) < time.Hour {
+		o.mu.Unlock()
+		return m
+	}
+	o.mu.Unlock()
+
+	m := map[string]DenomMeta{}
+	var body struct {
+		Denoms map[string]struct {
+			Symbol   string `json:"symbol"`
+			Decimals int    `json:"decimals"`
+		} `json:"denoms"`
+	}
+	if err := o.get(fmt.Sprintf("%s/denoms?chain=%s", o.base, chain), &body); err == nil {
+		for d, v := range body.Denoms {
+			m[d] = DenomMeta{Symbol: v.Symbol, Decimals: v.Decimals}
+		}
+	}
+
+	o.mu.Lock()
+	o.denoms[chain] = m
+	o.at[chain] = nowUTC()
+	o.mu.Unlock()
+	return m
+}
+
+// PriceAt returns the USD price for a denom on (or most recently before) a date
+// (YYYY-MM-DD). found=false when the oracle has no price.
+func (o *Oracle) PriceAt(chain, denom, date string) (float64, bool) {
+	var body struct {
+		USD   float64 `json:"usd"`
+		Found bool    `json:"found"`
+	}
+	url := fmt.Sprintf("%s/price?chain=%s&denom=%s&date=%s", o.base, chain, denom, date)
+	if err := o.get(url, &body); err != nil {
+		return 0, false
+	}
+	return body.USD, body.Found
+}
+
+func (o *Oracle) get(url string, out any) error {
+	resp, err := o.http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("oracle %s: %d", url, resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func nowUTC() time.Time { return time.Now().UTC() }

--- a/taxapi/reconcile.go
+++ b/taxapi/reconcile.go
@@ -1,0 +1,102 @@
+package taxapi
+
+import (
+	"time"
+
+	"github.com/DefiantLabs/cosmos-indexer/tax"
+)
+
+// supportedTypes is the set of message type URLs the tax parser classifies.
+var supportedTypes = func() map[string]bool {
+	m := make(map[string]bool, len(tax.MessageTypeURLs))
+	for _, u := range tax.MessageTypeURLs {
+		m[u] = true
+	}
+	return m
+}()
+
+// CoverageRow is per-message-type coverage over a block range.
+type CoverageRow struct {
+	MessageType  string `json:"message_type"`
+	Total        int64  `json:"total"`        // messages of this type in range
+	Classified   int64  `json:"classified"`   // of those, how many produced a taxable event
+	Supported    bool   `json:"supported"`    // is this type handled by the parser at all
+	Unclassified int64  `json:"unclassified"` // Total - Classified
+}
+
+// CoverageReport is the reconciliation summary an enterprise user needs to trust
+// that every taxable event has been accounted for: it lists every message type
+// seen on chain in the range, how many we classified, and which types are gaps
+// (seen but unsupported, e.g. CosmWasm MsgExecuteContract).
+type CoverageReport struct {
+	Start            string        `json:"start"`
+	End              string        `json:"end"`
+	TotalMessages    int64         `json:"total_messages"`
+	ClassifiedMsgs   int64         `json:"classified_messages"`
+	CoveragePercent  float64       `json:"coverage_percent"`
+	SupportedTypes   int           `json:"supported_types_seen"`
+	UnsupportedTypes int           `json:"unsupported_types_seen"`
+	Rows             []CoverageRow `json:"rows"`
+	// Gaps are types that appeared on chain but the parser does not handle —
+	// the explicit "here is what we are NOT yet reporting" list.
+	Gaps []CoverageRow `json:"gaps"`
+}
+
+// typeCount is one row of the reconciliation query: a message type and how many
+// of those messages exist / were classified in the range.
+type typeCount struct {
+	MessageType string
+	Total       int64
+	Classified  int64
+}
+
+// coverage runs the reconciliation query over [start,end) and summarizes it.
+func (s *Server) coverage(start, end time.Time) (*CoverageReport, error) {
+	var rows []typeCount
+	if err := s.db.Table("messages").
+		Select("message_types.message_type AS message_type, COUNT(DISTINCT messages.id) AS total, COUNT(DISTINCT taxable_events.message_id) AS classified").
+		Joins("JOIN message_types ON message_types.id = messages.message_type_id").
+		Joins("JOIN txes ON txes.id = messages.tx_id").
+		Joins("JOIN blocks ON blocks.id = txes.block_id").
+		Joins("LEFT JOIN taxable_events ON taxable_events.message_id = messages.id").
+		Where("blocks.time_stamp >= ? AND blocks.time_stamp < ?", start, end).
+		Group("message_types.message_type").
+		Order("total DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return summarizeCoverage(rows, start, end), nil
+}
+
+// summarizeCoverage turns raw per-type counts into the reconciliation report,
+// splitting types into supported vs gaps. Pure (no DB) so it is unit-testable.
+func summarizeCoverage(rows []typeCount, start, end time.Time) *CoverageReport {
+	rep := &CoverageReport{
+		Start: start.UTC().Format("2006-01-02"),
+		End:   end.UTC().Format("2006-01-02"),
+		Rows:  make([]CoverageRow, 0, len(rows)),
+		Gaps:  []CoverageRow{},
+	}
+	for _, r := range rows {
+		cr := CoverageRow{
+			MessageType:  r.MessageType,
+			Total:        r.Total,
+			Classified:   r.Classified,
+			Supported:    supportedTypes[r.MessageType],
+			Unclassified: r.Total - r.Classified,
+		}
+		rep.Rows = append(rep.Rows, cr)
+		rep.TotalMessages += r.Total
+		rep.ClassifiedMsgs += r.Classified
+		if cr.Supported {
+			rep.SupportedTypes++
+		} else {
+			rep.UnsupportedTypes++
+			rep.Gaps = append(rep.Gaps, cr)
+		}
+	}
+	if rep.TotalMessages > 0 {
+		rep.CoveragePercent = float64(rep.ClassifiedMsgs) / float64(rep.TotalMessages) * 100
+	}
+	return rep
+}

--- a/taxapi/reconcile_test.go
+++ b/taxapi/reconcile_test.go
@@ -1,0 +1,56 @@
+package taxapi
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSummarizeCoverage(t *testing.T) {
+	rows := []typeCount{
+		{MessageType: "/cosmwasm.wasm.v1.MsgExecuteContract", Total: 128, Classified: 0},
+		{MessageType: "/cosmos.bank.v1beta1.MsgSend", Total: 38, Classified: 38},
+		{MessageType: "/cosmos.staking.v1beta1.MsgDelegate", Total: 8, Classified: 5},
+	}
+	rep := summarizeCoverage(rows, time.Time{}, time.Time{})
+
+	if rep.TotalMessages != 174 || rep.ClassifiedMsgs != 43 {
+		t.Fatalf("totals wrong: total=%d classified=%d", rep.TotalMessages, rep.ClassifiedMsgs)
+	}
+	// 43/174 = 24.71%
+	if rep.CoveragePercent < 24.7 || rep.CoveragePercent > 24.72 {
+		t.Fatalf("coverage%% wrong: %v", rep.CoveragePercent)
+	}
+	if rep.SupportedTypes != 2 || rep.UnsupportedTypes != 1 {
+		t.Fatalf("type split wrong: supported=%d unsupported=%d", rep.SupportedTypes, rep.UnsupportedTypes)
+	}
+	// The single gap must be the WASM contract type, with its full count surfaced.
+	if len(rep.Gaps) != 1 || rep.Gaps[0].MessageType != "/cosmwasm.wasm.v1.MsgExecuteContract" || rep.Gaps[0].Unclassified != 128 {
+		t.Fatalf("gap detection wrong: %+v", rep.Gaps)
+	}
+	// A partially-classified supported type reports the remainder as unclassified.
+	var del CoverageRow
+	for _, r := range rep.Rows {
+		if r.MessageType == "/cosmos.staking.v1beta1.MsgDelegate" {
+			del = r
+		}
+	}
+	if !del.Supported || del.Unclassified != 3 {
+		t.Fatalf("delegate row wrong: %+v", del)
+	}
+}
+
+// supportedTypes must stay in lockstep with the parser's registered URLs.
+func TestSupportedTypesMatchParser(t *testing.T) {
+	if len(supportedTypes) == 0 {
+		t.Fatal("supportedTypes is empty")
+	}
+	for _, u := range []string{
+		"/cosmos.bank.v1beta1.MsgSend",
+		"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+		"/cosmos.authz.v1beta1.MsgExec",
+	} {
+		if !supportedTypes[u] {
+			t.Fatalf("expected %s to be supported", u)
+		}
+	}
+}

--- a/taxapi/reconcile_test.go
+++ b/taxapi/reconcile_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSummarizeCoverage(t *testing.T) {
 	rows := []typeCount{
-		{MessageType: "/cosmwasm.wasm.v1.MsgExecuteContract", Total: 128, Classified: 0},
+		{MessageType: "/ibc.core.client.v1.MsgUpdateClient", Total: 128, Classified: 0}, // relayer noise, unsupported
 		{MessageType: "/cosmos.bank.v1beta1.MsgSend", Total: 38, Classified: 38},
 		{MessageType: "/cosmos.staking.v1beta1.MsgDelegate", Total: 8, Classified: 5},
 	}
@@ -23,8 +23,8 @@ func TestSummarizeCoverage(t *testing.T) {
 	if rep.SupportedTypes != 2 || rep.UnsupportedTypes != 1 {
 		t.Fatalf("type split wrong: supported=%d unsupported=%d", rep.SupportedTypes, rep.UnsupportedTypes)
 	}
-	// The single gap must be the WASM contract type, with its full count surfaced.
-	if len(rep.Gaps) != 1 || rep.Gaps[0].MessageType != "/cosmwasm.wasm.v1.MsgExecuteContract" || rep.Gaps[0].Unclassified != 128 {
+	// The single gap must be the unsupported relayer type, full count surfaced.
+	if len(rep.Gaps) != 1 || rep.Gaps[0].MessageType != "/ibc.core.client.v1.MsgUpdateClient" || rep.Gaps[0].Unclassified != 128 {
 		t.Fatalf("gap detection wrong: %+v", rep.Gaps)
 	}
 	// A partially-classified supported type reports the remainder as unclassified.

--- a/taxapi/scheduled_test.go
+++ b/taxapi/scheduled_test.go
@@ -1,0 +1,29 @@
+package taxapi
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestBuildScheduleD(t *testing.T) {
+	rows := []Form8949Row{
+		{Proceeds: d(12), CostBasis: d(8), GainLoss: d(4), LongTerm: false},
+		{Proceeds: d(5), CostBasis: d(9), GainLoss: d(-4), LongTerm: false}, // short-term loss
+		{Proceeds: d(20), CostBasis: d(10), GainLoss: d(10), LongTerm: true},
+	}
+	sd := BuildScheduleD(rows)
+
+	if !sd.ShortTermGainLoss.Equal(decimal.Zero) { // 4 + (-4)
+		t.Fatalf("short-term gain wrong: %v", sd.ShortTermGainLoss)
+	}
+	if !sd.ShortTermProceeds.Equal(d(17)) || !sd.ShortTermCostBasis.Equal(d(17)) {
+		t.Fatalf("short-term totals wrong: %v / %v", sd.ShortTermProceeds, sd.ShortTermCostBasis)
+	}
+	if !sd.LongTermGainLoss.Equal(d(10)) {
+		t.Fatalf("long-term gain wrong: %v", sd.LongTermGainLoss)
+	}
+	if !sd.NetGainLoss.Equal(d(10)) { // 0 + 10
+		t.Fatalf("net gain wrong: %v", sd.NetGainLoss)
+	}
+}

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -110,12 +110,15 @@ func (s *Server) rowsFor(chain, addr string, start, end time.Time) ([]Row, error
 	for _, e := range events {
 		dir := "in"
 		switch e.Category {
-		case string(tax.CategoryTransfer), string(tax.CategoryIBCOut):
+		case string(tax.CategoryTransfer), string(tax.CategoryIBCOut), string(tax.CategoryNFTSale):
+			// Seller (FromAddr) disposes; everyone else (ToAddr) acquires.
 			if e.FromAddr == addr {
 				dir = "out"
 			}
 		}
-		out = append(out, s.buildRow(chain, meta, e.Timestamp, e.TxHash, e.Category, dir, e.Denom, e.Amount, e.FromAddr, e.ToAddr))
+		row := s.buildRow(chain, meta, e.Timestamp, e.TxHash, e.Category, dir, e.Denom, e.Amount, e.FromAddr, e.ToAddr)
+		row.Asset = e.Asset
+		out = append(out, row)
 	}
 
 	// Fees (generic SDK Fee table): a spend by the payer.

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -1,6 +1,7 @@
 package taxapi
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -24,6 +25,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /events", s.handleEvents)
 	mux.HandleFunc("GET /8949", s.handle8949)
 	mux.HandleFunc("GET /schedule-d", s.handleScheduleD)
+	mux.HandleFunc("GET /income", s.handleIncome)
 	mux.HandleFunc("GET /coverage", s.handleCoverage)
 	return withCORS(mux)
 }
@@ -80,6 +82,41 @@ func (s *Server) handleScheduleD(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(BuildScheduleD(Build8949(rows)))
+}
+
+// handleIncome returns an ordinary-income report (staking rewards + validator
+// commission, valued in USD at receipt) for Schedule 1 / Form 990-T. These are
+// income at the time received, distinct from the 8949's capital dispositions.
+func (s *Server) handleIncome(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	addr := q.Get("address")
+	if addr == "" {
+		http.Error(w, "address required", http.StatusBadRequest)
+		return
+	}
+	chain := def(q.Get("chain"), "mainnet")
+	rows, err := s.rowsFor(chain, addr, dateParam(q.Get("start"), time.Time{}), dateParam(q.Get("end"), nowUTC().AddDate(0, 0, 1)))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", "attachment; filename=income-schedule1-990t.csv")
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	_ = cw.Write([]string{"date_utc", "type", "symbol", "denom", "amount", "unit_price_usd", "value_usd", "tx_hash"})
+	total := decimal.Zero
+	for _, row := range rows {
+		if row.Category != "reward" && row.Category != "commission" {
+			continue
+		}
+		total = total.Add(row.ValueUSD)
+		_ = cw.Write([]string{
+			row.Time.UTC().Format("2006-01-02"), row.Category, row.Symbol, row.Denom,
+			row.Amount.String(), row.PriceUSD.String(), row.ValueUSD.StringFixed(2), row.TxHash,
+		})
+	}
+	_ = cw.Write([]string{"", "TOTAL", "", "", "", "", total.StringFixed(2), ""})
 }
 
 func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -28,6 +28,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /income", s.handleIncome)
 	mux.HandleFunc("GET /990t", s.handle990T)
 	mux.HandleFunc("GET /coverage", s.handleCoverage)
+	mux.HandleFunc("GET /balance", s.handleBalance)
 	return withCORS(mux)
 }
 

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -26,6 +26,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /8949", s.handle8949)
 	mux.HandleFunc("GET /schedule-d", s.handleScheduleD)
 	mux.HandleFunc("GET /income", s.handleIncome)
+	mux.HandleFunc("GET /990t", s.handle990T)
 	mux.HandleFunc("GET /coverage", s.handleCoverage)
 	return withCORS(mux)
 }
@@ -117,6 +118,32 @@ func (s *Server) handleIncome(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	_ = cw.Write([]string{"", "TOTAL", "", "", "", "", total.StringFixed(2), ""})
+}
+
+// handle990T computes the Form 990-T / UBIT estimate from an address's staking
+// income (for retirement-account wallets): gross UBTI, the $1,000 specific
+// deduction, taxable UBTI, and estimated tax at trust rates.
+func (s *Server) handle990T(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	addr := q.Get("address")
+	if addr == "" {
+		http.Error(w, "address required", http.StatusBadRequest)
+		return
+	}
+	chain := def(q.Get("chain"), "mainnet")
+	rows, err := s.rowsFor(chain, addr, dateParam(q.Get("start"), time.Time{}), dateParam(q.Get("end"), nowUTC().AddDate(0, 0, 1)))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	ubti := decimal.Zero
+	for _, row := range rows {
+		if row.Category == "reward" || row.Category == "commission" {
+			ubti = ubti.Add(row.ValueUSD)
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(compute990T(ubti))
 }
 
 func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -22,6 +22,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) })
 	mux.HandleFunc("GET /events", s.handleEvents)
 	mux.HandleFunc("GET /8949", s.handle8949)
+	mux.HandleFunc("GET /schedule-d", s.handleScheduleD)
 	mux.HandleFunc("GET /coverage", s.handleCoverage)
 	return withCORS(mux)
 }
@@ -61,6 +62,23 @@ func (s *Server) handle8949(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/csv")
 	w.Header().Set("Content-Disposition", "attachment; filename=form-8949.csv")
 	_ = Write8949CSV(w, Build8949(rows))
+}
+
+func (s *Server) handleScheduleD(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	addr := q.Get("address")
+	if addr == "" {
+		http.Error(w, "address required", http.StatusBadRequest)
+		return
+	}
+	chain := def(q.Get("chain"), "mainnet")
+	rows, err := s.rowsFor(chain, addr, dateParam(q.Get("start"), time.Time{}), dateParam(q.Get("end"), nowUTC().AddDate(0, 0, 1)))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(BuildScheduleD(Build8949(rows)))
 }
 
 func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -110,7 +110,7 @@ func (s *Server) handleIncome(w http.ResponseWriter, r *http.Request) {
 	_ = cw.Write([]string{"date_utc", "type", "symbol", "denom", "amount", "unit_price_usd", "value_usd", "tx_hash"})
 	total := decimal.Zero
 	for _, row := range rows {
-		if row.Category != "reward" && row.Category != "commission" {
+		if row.Category != categoryReward && row.Category != categoryCommission {
 			continue
 		}
 		total = total.Add(row.ValueUSD)
@@ -149,7 +149,7 @@ func (s *Server) handle990T(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, row := range rows {
-			if row.Category == "reward" || row.Category == "commission" {
+			if row.Category == categoryReward || row.Category == categoryCommission {
 				ubti = ubti.Add(row.ValueUSD)
 			}
 		}
@@ -185,12 +185,12 @@ func (s *Server) rowsFor(chain, addr string, start, end time.Time) ([]Row, error
 
 	out := make([]Row, 0, len(events)+8)
 	for _, e := range events {
-		dir := "in"
+		dir := directionIn
 		switch e.Category {
 		case string(tax.CategoryTransfer), string(tax.CategoryIBCOut), string(tax.CategoryNFTSale), string(tax.CategorySwap):
 			// Disposer (FromAddr) sends; everyone else (ToAddr) acquires.
 			if e.FromAddr == addr {
-				dir = "out"
+				dir = directionOut
 			}
 		}
 		row := s.buildRow(chain, meta, e.Timestamp, e.TxHash, e.Category, dir, e.Denom, e.Amount, e.FromAddr, e.ToAddr)
@@ -215,7 +215,7 @@ func (s *Server) rowsFor(chain, addr string, start, end time.Time) ([]Row, error
 		Where("addresses.address = ? AND blocks.time_stamp >= ? AND blocks.time_stamp < ?", addr, start, end).
 		Scan(&fees).Error; err == nil {
 		for _, f := range fees {
-			out = append(out, s.buildRow(chain, meta, f.Ts, f.Hash, "fee", "out", f.Denom, f.Amount, addr, ""))
+			out = append(out, s.buildRow(chain, meta, f.Ts, f.Hash, categoryFee, directionOut, f.Denom, f.Amount, addr, ""))
 		}
 	}
 

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -1,0 +1,168 @@
+package taxapi
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/DefiantLabs/cosmos-indexer/tax"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+type Server struct {
+	db     *gorm.DB
+	oracle *Oracle
+}
+
+func NewServer(db *gorm.DB, oracle *Oracle) *Server { return &Server{db: db, oracle: oracle} }
+
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) })
+	mux.HandleFunc("GET /events", s.handleEvents)
+	mux.HandleFunc("GET /8949", s.handle8949)
+	return withCORS(mux)
+}
+
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	addr := q.Get("address")
+	if addr == "" {
+		http.Error(w, "address required", http.StatusBadRequest)
+		return
+	}
+	chain := def(q.Get("chain"), "mainnet")
+	format := def(q.Get("format"), "summ")
+	rows, err := s.rowsFor(chain, addr, dateParam(q.Get("start"), time.Time{}), dateParam(q.Get("end"), nowUTC().AddDate(0, 0, 1)))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", "attachment; filename=cosmos-tax-"+format+".csv")
+	_ = WriteCSV(w, format, rows)
+}
+
+func (s *Server) handle8949(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	addr := q.Get("address")
+	if addr == "" {
+		http.Error(w, "address required", http.StatusBadRequest)
+		return
+	}
+	chain := def(q.Get("chain"), "mainnet")
+	rows, err := s.rowsFor(chain, addr, dateParam(q.Get("start"), time.Time{}), dateParam(q.Get("end"), nowUTC().AddDate(0, 0, 1)))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", "attachment; filename=form-8949.csv")
+	_ = Write8949CSV(w, Build8949(rows))
+}
+
+// rowsFor loads classified taxable events + fees for an address in [start,end),
+// resolves denoms + USD prices, and returns normalized Rows.
+func (s *Server) rowsFor(chain, addr string, start, end time.Time) ([]Row, error) {
+	meta := s.oracle.Denoms(chain)
+
+	var events []tax.TaxableEvent
+	if err := s.db.
+		Where("(from_addr = ? OR to_addr = ?)", addr, addr).
+		Where("timestamp >= ? AND timestamp < ?", start, end).
+		Order("timestamp asc").
+		Find(&events).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]Row, 0, len(events)+8)
+	for _, e := range events {
+		dir := "in"
+		switch e.Category {
+		case string(tax.CategoryTransfer), string(tax.CategoryIBCOut):
+			if e.FromAddr == addr {
+				dir = "out"
+			}
+		}
+		out = append(out, s.buildRow(chain, meta, e.Timestamp, e.TxHash, e.Category, dir, e.Denom, e.Amount, e.FromAddr, e.ToAddr))
+	}
+
+	// Fees (generic SDK Fee table): a spend by the payer.
+	type feeRec struct {
+		Amount string
+		Denom  string
+		Ts     time.Time
+		Hash   string
+	}
+	var fees []feeRec
+	if err := s.db.Table("fees").
+		Select("fees.amount::text AS amount, denoms.base AS denom, blocks.time_stamp AS ts, txes.hash AS hash").
+		Joins("JOIN addresses ON addresses.id = fees.payer_address_id").
+		Joins("JOIN denoms ON denoms.id = fees.denomination_id").
+		Joins("JOIN txes ON txes.id = fees.tx_id").
+		Joins("JOIN blocks ON blocks.id = txes.block_id").
+		Where("addresses.address = ? AND blocks.time_stamp >= ? AND blocks.time_stamp < ?", addr, start, end).
+		Scan(&fees).Error; err == nil {
+		for _, f := range fees {
+			out = append(out, s.buildRow(chain, meta, f.Ts, f.Hash, "fee", "out", f.Denom, f.Amount, addr, ""))
+		}
+	}
+
+	return out, nil
+}
+
+func (s *Server) buildRow(chain string, meta map[string]DenomMeta, ts time.Time, hash, category, dir, denom, amountBase, from, to string) Row {
+	m, ok := meta[denom]
+	decimals := 6
+	symbol := denom
+	if ok {
+		decimals = m.Decimals
+		if m.Symbol != "" {
+			symbol = m.Symbol
+		}
+	}
+	amt, err := decimal.NewFromString(amountBase)
+	if err != nil {
+		amt = decimal.Zero
+	}
+	amt = amt.Shift(int32(-decimals))
+
+	price := decimal.Zero
+	if usdF, found := s.oracle.PriceAt(chain, denom, ts.UTC().Format("2006-01-02")); found {
+		price = decimal.NewFromFloat(usdF)
+	}
+	return Row{
+		Time: ts, Category: category, Direction: dir,
+		Symbol: symbol, Denom: denom, Amount: amt,
+		PriceUSD: price, ValueUSD: amt.Mul(price),
+		From: from, To: to, TxHash: hash,
+	}
+}
+
+func def(v, d string) string {
+	if v == "" {
+		return d
+	}
+	return v
+}
+
+func dateParam(v string, fallback time.Time) time.Time {
+	if v == "" {
+		return fallback
+	}
+	if t, err := time.Parse("2006-01-02", v); err == nil {
+		return t
+	}
+	return fallback
+}
+
+func withCORS(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -1,6 +1,7 @@
 package taxapi
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -21,6 +22,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) })
 	mux.HandleFunc("GET /events", s.handleEvents)
 	mux.HandleFunc("GET /8949", s.handle8949)
+	mux.HandleFunc("GET /coverage", s.handleCoverage)
 	return withCORS(mux)
 }
 
@@ -59,6 +61,17 @@ func (s *Server) handle8949(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/csv")
 	w.Header().Set("Content-Disposition", "attachment; filename=form-8949.csv")
 	_ = Write8949CSV(w, Build8949(rows))
+}
+
+func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	rep, err := s.coverage(dateParam(q.Get("start"), time.Time{}), dateParam(q.Get("end"), nowUTC().AddDate(0, 0, 1)))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(rep)
 }
 
 // rowsFor loads classified taxable events + fees for an address in [start,end),

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -3,6 +3,7 @@ package taxapi
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/DefiantLabs/cosmos-indexer/tax"
@@ -146,9 +147,14 @@ func (s *Server) rowsFor(chain, addr string, start, end time.Time) ([]Row, error
 }
 
 func (s *Server) buildRow(chain string, meta map[string]DenomMeta, ts time.Time, hash, category, dir, denom, amountBase, from, to string) Row {
-	m, ok := meta[denom]
+	// IBC voucher denoms arrive as trace paths (e.g. "transfer/channel-0/uatom").
+	// Resolve to the underlying base asset so symbol, decimals and price match the
+	// native token (uatom that round-trips is still ATOM); keep the raw path.
+	base, isIBC := ibcBaseDenom(denom)
+
+	m, ok := meta[base]
 	decimals := 6
-	symbol := denom
+	symbol := base
 	if ok {
 		decimals = m.Decimals
 		if m.Symbol != "" {
@@ -162,15 +168,31 @@ func (s *Server) buildRow(chain string, meta map[string]DenomMeta, ts time.Time,
 	amt = amt.Shift(int32(-decimals))
 
 	price := decimal.Zero
-	if usdF, found := s.oracle.PriceAt(chain, denom, ts.UTC().Format("2006-01-02")); found {
+	if usdF, found := s.oracle.PriceAt(chain, base, ts.UTC().Format("2006-01-02")); found {
 		price = decimal.NewFromFloat(usdF)
 	}
 	return Row{
 		Time: ts, Category: category, Direction: dir,
 		Symbol: symbol, Denom: denom, Amount: amt,
 		PriceUSD: price, ValueUSD: amt.Mul(price),
-		From: from, To: to, TxHash: hash,
+		From: from, To: to, TxHash: hash, IsIBC: isIBC,
 	}
+}
+
+// ibcBaseDenom strips leading IBC trace prefixes ("transfer/channel-N/" and
+// "<wasm-port>/channel/" pairs) from a voucher denom, returning the underlying
+// base denom and whether a prefix was stripped. "transfer/channel-0/uatom" ->
+// ("uatom", true); "ibc/HASH" and "uatom" pass through unchanged (false).
+func ibcBaseDenom(denom string) (string, bool) {
+	parts := strings.Split(denom, "/")
+	i := 0
+	for i+1 < len(parts) && (parts[i] == "transfer" || strings.HasPrefix(parts[i], "08-wasm-")) {
+		i += 2
+	}
+	if i == 0 {
+		return denom, false
+	}
+	return strings.Join(parts[i:], "/"), true
 }
 
 func def(v, d string) string {

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -22,6 +22,7 @@ func NewServer(db *gorm.DB, oracle *Oracle) *Server { return &Server{db: db, ora
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) })
+	mux.HandleFunc("GET /metrics", s.handleMetrics)
 	mux.HandleFunc("GET /events", s.handleEvents)
 	mux.HandleFunc("GET /8949", s.handle8949)
 	mux.HandleFunc("GET /schedule-d", s.handleScheduleD)

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -131,15 +131,25 @@ func (s *Server) handle990T(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	chain := def(q.Get("chain"), "mainnet")
-	rows, err := s.rowsFor(chain, addr, dateParam(q.Get("start"), time.Time{}), dateParam(q.Get("end"), nowUTC().AddDate(0, 0, 1)))
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	start := dateParam(q.Get("start"), time.Time{})
+	end := dateParam(q.Get("end"), nowUTC().AddDate(0, 0, 1))
+	// An entity may hold several wallets; the $1,000 deduction is per return, so
+	// sum staking income across all of them, then compute one 990-T.
 	ubti := decimal.Zero
-	for _, row := range rows {
-		if row.Category == "reward" || row.Category == "commission" {
-			ubti = ubti.Add(row.ValueUSD)
+	for _, a := range strings.Split(addr, ",") {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		rows, err := s.rowsFor(chain, a, start, end)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		for _, row := range rows {
+			if row.Category == "reward" || row.Category == "commission" {
+				ubti = ubti.Add(row.ValueUSD)
+			}
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/taxapi/server.go
+++ b/taxapi/server.go
@@ -148,8 +148,8 @@ func (s *Server) rowsFor(chain, addr string, start, end time.Time) ([]Row, error
 	for _, e := range events {
 		dir := "in"
 		switch e.Category {
-		case string(tax.CategoryTransfer), string(tax.CategoryIBCOut), string(tax.CategoryNFTSale):
-			// Seller (FromAddr) disposes; everyone else (ToAddr) acquires.
+		case string(tax.CategoryTransfer), string(tax.CategoryIBCOut), string(tax.CategoryNFTSale), string(tax.CategorySwap):
+			// Disposer (FromAddr) sends; everyone else (ToAddr) acquires.
 			if e.FromAddr == addr {
 				dir = "out"
 			}

--- a/taxapid/main.go
+++ b/taxapid/main.go
@@ -1,0 +1,45 @@
+// taxapid serves the tax query/export API over the database the tax indexer
+// writes, using the wasm-indexer oracle for USD pricing + denom resolution.
+//
+// Env: DB_HOST DB_PORT DB_NAME DB_USER DB_PASS, ORACLE_URL (wasm-indexer base,
+// e.g. http://wasm-indexer:8080), LISTEN (default :8082).
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	indexerDB "github.com/DefiantLabs/cosmos-indexer/db"
+	"github.com/DefiantLabs/cosmos-indexer/taxapi"
+)
+
+func env(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}
+
+func main() {
+	db, err := indexerDB.PostgresDbConnect(
+		env("DB_HOST", "localhost"),
+		env("DB_PORT", "5432"),
+		env("DB_NAME", "indexer"),
+		env("DB_USER", "postgres"),
+		env("DB_PASS", "postgres"),
+		env("DB_LOG_LEVEL", "warn"),
+	)
+	if err != nil {
+		log.Fatalf("db connect: %v", err)
+	}
+
+	oracle := taxapi.NewOracle(env("ORACLE_URL", "http://wasm-indexer:8080"))
+	srv := taxapi.NewServer(db, oracle)
+
+	listen := env("LISTEN", ":8082")
+	log.Printf("tax-api listening on %s", listen)
+	if err := http.ListenAndServe(listen, srv.Handler()); err != nil {
+		log.Fatalf("serve: %v", err)
+	}
+}

--- a/taxapid/main.go
+++ b/taxapid/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	indexerDB "github.com/DefiantLabs/cosmos-indexer/db"
 	"github.com/DefiantLabs/cosmos-indexer/taxapi"
@@ -45,7 +46,12 @@ func main() {
 
 	listen := env("LISTEN", ":8082")
 	log.Printf("tax-api listening on %s", listen)
-	if err := http.ListenAndServe(listen, srv.Handler()); err != nil {
+	server := &http.Server{
+		Addr:              listen,
+		Handler:           srv.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil {
 		log.Fatalf("serve: %v", err)
 	}
 }

--- a/taxapid/main.go
+++ b/taxapid/main.go
@@ -34,6 +34,12 @@ func main() {
 		log.Fatalf("db connect: %v", err)
 	}
 
+	// Own the balance-snapshot table (the SDK now serves /balance, replacing the
+	// legacy cosmos-tax-cli). Live reads come from NODE_REST_API.
+	if err := db.AutoMigrate(&taxapi.BalanceSnapshot{}); err != nil {
+		log.Printf("balance table migrate: %v", err)
+	}
+
 	oracle := taxapi.NewOracle(env("ORACLE_URL", "http://wasm-indexer:8080"))
 	srv := taxapi.NewServer(db, oracle)
 

--- a/taxindexer/main.go
+++ b/taxindexer/main.go
@@ -1,0 +1,36 @@
+// taxindexer runs the cosmos-indexer SDK with the tax classification layer
+// registered: it indexes a chain generically AND writes TaxableEvent rows for
+// the events that matter for Cosmos tax reporting (bank transfers, staking
+// rewards, validator commission, IBC in/out). Fees come from the SDK's generic
+// Fee model. Run like the base indexer (config.toml or --flags), e.g.:
+//
+//	tax-indexer index --config config.toml
+package main
+
+import (
+	"log"
+
+	"github.com/DefiantLabs/cosmos-indexer/cmd"
+	"github.com/DefiantLabs/cosmos-indexer/tax"
+)
+
+func main() {
+	indexer := cmd.GetBuiltinIndexer()
+
+	// Custom table for classified taxable events (auto-migrated on startup).
+	indexer.RegisterCustomModels([]any{&tax.TaxableEvent{}})
+
+	// One parser instance handles every taxable message type.
+	parser := &tax.Parser{ID: "tax-parser"}
+	for _, url := range tax.MessageTypeURLs {
+		indexer.RegisterCustomMessageParser(url, parser)
+	}
+
+	// No message-type filter: the SDK still indexes ALL messages/events
+	// generically (needed for the completeness/reconciliation guarantee), and
+	// our parser layers taxable events on top of the handled types.
+
+	if err := cmd.Execute(); err != nil {
+		log.Fatalf("tax-indexer failed: %v", err)
+	}
+}

--- a/taxindexer/main.go
+++ b/taxindexer/main.go
@@ -20,10 +20,10 @@ func main() {
 	// Custom table for classified taxable events (auto-migrated on startup).
 	indexer.RegisterCustomModels([]any{&tax.TaxableEvent{}})
 
-	// One parser instance handles every taxable message type.
-	parser := &tax.Parser{ID: "tax-parser"}
+	// The SDK requires each registered parser to have a globally-unique
+	// identifier, so register a distinct instance (same logic) per type URL.
 	for _, url := range tax.MessageTypeURLs {
-		indexer.RegisterCustomMessageParser(url, parser)
+		indexer.RegisterCustomMessageParser(url, &tax.Parser{ID: "tax:" + url})
 	}
 
 	// No message-type filter: the SDK still indexes ALL messages/events


### PR DESCRIPTION
Adds a stdlib Prometheus `/metrics` endpoint to taxapi (no client_golang dep). It queries the blocks table for the indexer's newest height/time and exposes:

- `taxindexer_latest_block_height`
- `taxindexer_blocks_indexed`
- `taxindexer_latest_block_time_seconds`
- `taxindexer_data_age_seconds` (seconds since the newest indexed block)

The API shares the indexer's database, so these reflect indexer freshness. Prometheus scrapes it via pod annotations (port 8082, path /metrics) on the mainnet and testnet tax API deployments, driving the tax panels + TaxIndexerStalled/NoData alerts on the Website Health dashboard.

Built via Dockerfile.tax as ghcr.io/bryanlabs/cosmos-tax-sdk:1cbc6e9-tax and deployed live; both indexers report ~13s data age (tracking chain tip).